### PR TITLE
Core port: storage, importer, reports, CLI and desktop UI (Phases 2–7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,9 +96,16 @@ jobs:
           cp release-assets/census-linux-x64/app/Census.App    flat/Census.App-linux-x64      || true
           chmod +x flat/census-osx-* flat/census-linux-* flat/Census.App-osx-* flat/Census.App-linux-* 2>/dev/null || true
           ls -lh flat/
+      - name: Generate checksums
+        run: |
+          cd flat
+          sha256sum * > checksums.txt
+          cat checksums.txt
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
           draft: false
           generate_release_notes: true
-          files: flat/*
+          files: |
+            flat/*
+            flat/checksums.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,38 @@ jobs:
         with:
           name: census-${{ matrix.rid }}
           path: artifacts/${{ matrix.rid }}
+
+  release:
+    name: Create GitHub Release
+    needs: publish
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          pattern: census-*
+          merge-multiple: false
+      - name: Flatten and rename assets
+        run: |
+          mkdir -p flat
+          # cli binaries
+          cp release-assets/census-win-x64/cli/census.exe    flat/census-win-x64.exe         || true
+          cp release-assets/census-win-x64/app/Census.App.exe flat/Census.App-win-x64.exe    || true
+          cp release-assets/census-osx-arm64/cli/census        flat/census-osx-arm64          || true
+          cp release-assets/census-osx-arm64/app/Census.App    flat/Census.App-osx-arm64      || true
+          cp release-assets/census-osx-x64/cli/census          flat/census-osx-x64            || true
+          cp release-assets/census-osx-x64/app/Census.App      flat/Census.App-osx-x64        || true
+          cp release-assets/census-linux-x64/cli/census        flat/census-linux-x64          || true
+          cp release-assets/census-linux-x64/app/Census.App    flat/Census.App-linux-x64      || true
+          chmod +x flat/census-osx-* flat/census-linux-* flat/Census.App-osx-* flat/Census.App-linux-* 2>/dev/null || true
+          ls -lh flat/
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: false
+          generate_release_notes: true
+          files: flat/*

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,6 @@
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageVersion Include="CsvHelper" Version="33.1.0" />
     <PackageVersion Include="Dapper" Version="2.1.79" />
-    <PackageVersion Include="dbup-sqlite" Version="6.0.4" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="Scriban" Version="7.2.4" />

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -86,7 +86,7 @@ via SQLitePCLRaw, and Avalonia bundles Skia.
 | | source-generated `Regex` (in-box) | Listing parsing; replaces vendored `regexpr.pas`. |
 | `Census.Storage` | `Microsoft.Data.Sqlite` | Native SQLite access. |
 | | `Dapper` | Fast, lean query → object mapping. |
-| | `DbUp-SQLite` | Versioned, idempotent migration scripts. |
+| | *(in-house migrator)* | Versioned, idempotent embedded-SQL migrations. Replaces the planned `DbUp-SQLite` to avoid pulling a second SQLite native engine into the process (keeps the dependency surface minimal). |
 | `Census.Reports` | `Scriban` | HTML/LaTeX templating (no runtime compilation, fast, trim-friendly). |
 | | `CsvHelper` | Correct CSV quoting/escaping (replaces hand-built strings). |
 | `Census.Archive` | `System.IO.Compression` (in-box) | ZIP creation (replaces Lazarus `Zipper`). |

--- a/docs/superpowers/plans/2026-06-10-phase3-nonmem-xml-importer.md
+++ b/docs/superpowers/plans/2026-06-10-phase3-nonmem-xml-importer.md
@@ -1,0 +1,731 @@
+# Phase 3 — NONMEM XML Importer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement `NonmemXmlImporter.Import()` so it reads a NONMEM 7.2+ XML output file and returns a fully-populated `Run` domain object, verified by fixture-based tests.
+
+**Architecture:** Parse with `XDocument` (LINQ to XML), selecting by local element name so the importer is robust to namespace variations in real NONMEM output files. All data extracted from a single XML file; `DOfv`, `ObsRecs`, and `Individuals` are left null (unavailable from a single file). `RunNo`/`IRunNo` are derived from the filename stem.
+
+**Tech Stack:** `System.Xml.Linq` (in-box), `System.Security.Cryptography.MD5` (in-box), `Census.Import`, `Census.Domain`, `xUnit`.
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `tests/Census.Tests/fixtures/run27.xml` | Hand-crafted NONMEM XML fixture |
+| Modify | `src/Census.Import/NonmemXmlImporter.cs` | Full `Import()` implementation |
+| Create | `tests/Census.Tests/NonmemXmlImporterTests.cs` | Fixture-based + inline XML tests |
+
+---
+
+## Key schema facts (from `output.xsd` and `output.dtd`, NONMEM 7.6.0)
+
+```
+nm:output  (xmlns:nm="http://namespaces.oreilly.com/xmlnut/address")
+  nm:nonmem [@nm:version]
+    nm:problem [@nm:number]
+      nm:problem_options [@nm:data_nobs, @nm:data_nind]
+                                         → Run.ObsRecs, Run.Individuals
+      nm:estimation [@nm:number, @nm:type]
+        nm:estimation_method             → Estimation.Method
+        nm:termination_status            → if != 0: termination_information added to Warnings
+        nm:termination_information       → warning text
+        nm:final_objective_function      → Estimation.Ofv
+        nm:theta     (vector)  val[@name]   → ParameterKind.Theta estimates
+        nm:thetase   (vector)  val[@name]   → Theta StandardErrors
+        nm:omega     (table)   row/col      → ParameterKind.Omega estimates (diagonal only)
+        nm:omegase   (table)   row/col      → Omega StandardErrors (diagonal only)
+        nm:etashrinksd (table) row/col      → Omega Shrinkage, SD-based (NONMEM 7.3+)
+        nm:etashrink   (table) row/col      → Omega Shrinkage, legacy (NONMEM 7.2)
+        nm:sigma     (table)   row/col      → ParameterKind.Sigma estimates (diagonal)
+        nm:sigmase   (table)   row/col      → Sigma StandardErrors (diagonal)
+        nm:epsshrinksd (table) row/col      → Sigma Shrinkage, SD-based (NONMEM 7.3+)
+        nm:epsshrink   (table) row/col      → Sigma Shrinkage, legacy (NONMEM 7.2)
+        nm:covariance_status [@nm:mineigenvalue, @nm:maxeigenvalue]
+                                         → ConditionNumber = max/min
+      nm:sir_estimation [@nm:number, @nm:type]  — same structure as estimation, handle identically
+```
+
+**Namespace strategy:** real NONMEM output uses `nm:` prefix on ALL elements AND attributes
+(e.g. `<nm:problem nm:number="1">`). Select by `Name.LocalName` and `Attributes().FirstOrDefault(a => a.Name.LocalName == "x")` throughout — handles both namespaced and bare output.
+
+**Omega/Sigma matrix diagonal:** stored lower-triangular. Row i has i columns; diagonal = last `col` in each row.
+
+**Shrinkage priority:** prefer `etashrinksd` over `etashrink` (try `etashrinksd` first; fall back to `etashrink`). Same for eps. Each row = one eta/epsilon; the **first** `col` in that row is the shrinkage value.
+
+---
+
+## Task 1: Create fixture XML
+
+**Files:**
+- Create: `tests/Census.Tests/fixtures/run27.xml`
+
+- [ ] **Step 1: Create the fixture directory and file**
+
+Create `tests/Census.Tests/fixtures/run27.xml` with this content (NONMEM 7.6 format with `nm:` namespace prefix on all elements and attributes, per `output.dtd`):
+
+```xml
+<?xml version="1.0" encoding="ASCII"?>
+<nm:output xmlns:nm="http://namespaces.oreilly.com/xmlnut/address">
+  <nm:start_datetime>2024-01-15T10:30:00</nm:start_datetime>
+  <nm:control_stream>$PROB run27</nm:control_stream>
+  <nm:nmtran>SUCCESSFUL</nm:nmtran>
+  <nm:nonmem nm:version="7.6.0">
+    <nm:license_information>NONMEM 7.6.0</nm:license_information>
+    <nm:program_information>ICON plc</nm:program_information>
+    <nm:problem nm:number="1" nm:subproblem="0" nm:superproblem1="0" nm:iteration1="0" nm:superproblem2="0" nm:iteration2="0">
+      <nm:problem_title>$PROBLEM run27</nm:problem_title>
+      <nm:problem_information>NONMEM run 27</nm:problem_information>
+      <nm:problem_options nm:data_nobs="1234" nm:data_nind="56"/>
+      <nm:estimation nm:number="1" nm:type="1">
+        <nm:estimation_method>FOCEI</nm:estimation_method>
+        <nm:termination_status>0</nm:termination_status>
+        <nm:termination_information>MINIMIZATION SUCCESSFUL</nm:termination_information>
+        <nm:etashrinksd nm:number="1">
+          <nm:row nm:rname="ETA(1)">
+            <nm:col nm:cname="ETA(1)">12.3</nm:col>
+          </nm:row>
+        </nm:etashrinksd>
+        <nm:epsshrinksd nm:number="1">
+          <nm:row nm:rname="EPS(1)">
+            <nm:col nm:cname="EPS(1)">5.6</nm:col>
+          </nm:row>
+        </nm:epsshrinksd>
+        <nm:final_objective_function>-1234.567</nm:final_objective_function>
+        <nm:theta nm:number="1">
+          <nm:val nm:name="CL">3.21</nm:val>
+          <nm:val nm:name="V">15.4</nm:val>
+        </nm:theta>
+        <nm:omega nm:number="1">
+          <nm:row nm:rname="ETA(1)">
+            <nm:col nm:cname="ETA(1)">0.09</nm:col>
+          </nm:row>
+        </nm:omega>
+        <nm:sigma nm:number="1">
+          <nm:row nm:rname="EPS(1)">
+            <nm:col nm:cname="EPS(1)">0.04</nm:col>
+          </nm:row>
+        </nm:sigma>
+        <nm:thetase nm:number="1">
+          <nm:val nm:name="CL">0.05</nm:val>
+          <nm:val nm:name="V">0.80</nm:val>
+        </nm:thetase>
+        <nm:omegase nm:number="1">
+          <nm:row nm:rname="ETA(1)">
+            <nm:col nm:cname="ETA(1)">0.01</nm:col>
+          </nm:row>
+        </nm:omegase>
+        <nm:sigmase nm:number="1">
+          <nm:row nm:rname="EPS(1)">
+            <nm:col nm:cname="EPS(1)">0.005</nm:col>
+          </nm:row>
+        </nm:sigmase>
+        <nm:eigenvalues nm:number="1">
+          <nm:val nm:name="1">1.5</nm:val>
+          <nm:val nm:name="2">30.0</nm:val>
+        </nm:eigenvalues>
+        <nm:covariance_status nm:error="0" nm:numnegeigenvalues="0" nm:mineigenvalue="1.5" nm:maxeigenvalue="30.0" nm:rms="0.01"/>
+      </nm:estimation>
+    </nm:problem>
+  </nm:nonmem>
+  <nm:stop_datetime>2024-01-15T10:35:00</nm:stop_datetime>
+  <nm:total_cputime>12.34</nm:total_cputime>
+</nm:output>
+```
+
+- [ ] **Step 2: Mark file as embedded resource in Census.Tests.csproj**
+
+Open `tests/Census.Tests/Census.Tests.csproj`. Add:
+
+```xml
+<ItemGroup>
+  <EmbeddedResource Include="fixtures\**\*" />
+</ItemGroup>
+```
+
+Wait — for tests it's simpler to use the file on disk. Instead, add this so the fixture is copied to the output directory:
+
+```xml
+<ItemGroup>
+  <None Include="fixtures\**\*">
+    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+  </None>
+</ItemGroup>
+```
+
+---
+
+## Task 2: Write failing tests
+
+**Files:**
+- Create: `tests/Census.Tests/NonmemXmlImporterTests.cs`
+
+- [ ] **Step 1: Create the test file**
+
+```csharp
+using Census.Domain;
+using Census.Import;
+using Xunit;
+
+namespace Census.Tests;
+
+public sealed class NonmemXmlImporterTests
+{
+    private static string FixturePath(string name) =>
+        Path.Combine(AppContext.BaseDirectory, "fixtures", name);
+
+    [Fact]
+    public void CanImport_ReturnsTrueForXmlExtension()
+    {
+        Assert.True(new NonmemXmlImporter().CanImport("run27.xml"));
+        Assert.True(new NonmemXmlImporter().CanImport("RUN27.XML"));
+        Assert.False(new NonmemXmlImporter().CanImport("run27.lst"));
+    }
+
+    [Fact]
+    public void Import_Fixture_ExtractsRunNo()
+    {
+        var run = new NonmemXmlImporter().Import(FixturePath("run27.xml"));
+
+        Assert.Equal("27", run.RunNo);
+        Assert.Equal(27, run.IRunNo);
+    }
+
+    [Fact]
+    public void Import_Fixture_ExtractsObsRecsAndIndividuals()
+    {
+        var run = new NonmemXmlImporter().Import(FixturePath("run27.xml"));
+
+        Assert.Equal(1234, run.ObsRecs);
+        Assert.Equal(56, run.Individuals);
+    }
+
+    [Fact]
+    public void Import_Fixture_ExtractsEstimationMethod()
+    {
+        var run = new NonmemXmlImporter().Import(FixturePath("run27.xml"));
+
+        var est = Assert.Single(run.Estimations);
+        Assert.Equal(1, est.Number);
+        Assert.Equal("FOCEI", est.Method);
+    }
+
+    [Fact]
+    public void Import_Fixture_ExtractsOfv()
+    {
+        var run = new NonmemXmlImporter().Import(FixturePath("run27.xml"));
+
+        var est = Assert.Single(run.Estimations);
+        Assert.Equal(-1234.567, est.Ofv, precision: 3);
+    }
+
+    [Fact]
+    public void Import_Fixture_ExtractsThetaParameters()
+    {
+        var run = new NonmemXmlImporter().Import(FixturePath("run27.xml"));
+        var params_ = run.Estimations[0].Parameters;
+
+        var thetas = params_.Where(p => p.Kind == ParameterKind.Theta).ToList();
+        Assert.Equal(2, thetas.Count);
+
+        Assert.Equal(1, thetas[0].Index);
+        Assert.Equal("CL", thetas[0].Label);
+        Assert.Equal(3.21, thetas[0].Estimate, precision: 3);
+        Assert.Equal(0.05, thetas[0].StandardError, precision: 3);
+
+        Assert.Equal(2, thetas[1].Index);
+        Assert.Equal("V", thetas[1].Label);
+        Assert.Equal(15.4, thetas[1].Estimate, precision: 3);
+        Assert.Equal(0.80, thetas[1].StandardError, precision: 3);
+    }
+
+    [Fact]
+    public void Import_Fixture_ExtractsOmegaWithShrinkage()
+    {
+        var run = new NonmemXmlImporter().Import(FixturePath("run27.xml"));
+        var omega = Assert.Single(run.Estimations[0].Parameters, p => p.Kind == ParameterKind.Omega);
+
+        Assert.Equal(1, omega.Index);
+        Assert.Equal(0.09, omega.Estimate, precision: 3);
+        Assert.Equal(0.01, omega.StandardError, precision: 3);
+        Assert.Equal(12.3, omega.Shrinkage, precision: 2);
+    }
+
+    [Fact]
+    public void Import_Fixture_ExtractsSigmaWithShrinkage()
+    {
+        var run = new NonmemXmlImporter().Import(FixturePath("run27.xml"));
+        var sigma = Assert.Single(run.Estimations[0].Parameters, p => p.Kind == ParameterKind.Sigma);
+
+        Assert.Equal(1, sigma.Index);
+        Assert.Equal(0.04, sigma.Estimate, precision: 3);
+        Assert.Equal(0.005, sigma.StandardError, precision: 3);
+        Assert.Equal(5.6, sigma.Shrinkage, precision: 2);
+    }
+
+    [Fact]
+    public void Import_Fixture_ExtractsConditionNumber()
+    {
+        var run = new NonmemXmlImporter().Import(FixturePath("run27.xml"));
+        var est = run.Estimations[0];
+
+        Assert.Equal(20.0, est.ConditionNumber!.Value, precision: 2); // 30.0 / 1.5
+    }
+
+    [Fact]
+    public void Import_Fixture_NoWarningsOnSuccess()
+    {
+        var run = new NonmemXmlImporter().Import(FixturePath("run27.xml"));
+        Assert.Empty(run.Estimations[0].Warnings);
+    }
+
+    [Fact]
+    public void Import_Fixture_AddsXmlFileArtifactWithMd5()
+    {
+        var path = FixturePath("run27.xml");
+        var run = new NonmemXmlImporter().Import(path);
+
+        var artifact = Assert.Single(run.Files);
+        Assert.Equal("output", artifact.Role);
+        Assert.Equal(path, artifact.Path);
+        Assert.NotNull(artifact.Md5);
+        Assert.Equal(32, artifact.Md5!.Length); // hex MD5 is 32 chars
+    }
+
+    [Fact]
+    public void Import_InlineXml_CapturesTerminationWarning()
+    {
+        var xml = """
+            <?xml version="1.0"?>
+            <output>
+              <start_datetime>2024-01-15T10:30:00</start_datetime>
+              <control_stream></control_stream>
+              <nmtran></nmtran>
+              <nonmem version="7.4.4">
+                <license_information></license_information>
+                <program_information></program_information>
+                <problem number="1" subproblem="0" superproblem1="0" iteration1="0" superproblem2="0" iteration2="0">
+                  <problem_title></problem_title>
+                  <problem_information></problem_information>
+                  <estimation number="1" type="1">
+                    <estimation_method>FOCEI</estimation_method>
+                    <termination_status>1</termination_status>
+                    <termination_information>MINIMIZATION TERMINATED</termination_information>
+                    <final_objective_function>-500.0</final_objective_function>
+                  </estimation>
+                </problem>
+              </nonmem>
+              <stop_datetime>2024-01-15T10:35:00</stop_datetime>
+            </output>
+            """;
+
+        var run = new NonmemXmlImporter().ImportXml(xml, sourcePath: "run5.xml");
+        var est = Assert.Single(run.Estimations);
+        Assert.Equal("MINIMIZATION TERMINATED", Assert.Single(est.Warnings));
+    }
+
+    [Fact]
+    public void Import_InlineXml_LegacyEtashrinkFallback()
+    {
+        // NONMEM 7.2-era files use "etashrink"/"epsshrink" instead of "etashrinksd"/"epsshrinksd".
+        var xml = """
+            <?xml version="1.0"?>
+            <output>
+              <start_datetime>2024-01-15T10:30:00</start_datetime>
+              <control_stream></control_stream>
+              <nmtran></nmtran>
+              <nonmem version="7.2.0">
+                <license_information></license_information>
+                <program_information></program_information>
+                <problem number="1" subproblem="0" superproblem1="0" iteration1="0" superproblem2="0" iteration2="0">
+                  <problem_title></problem_title>
+                  <problem_information></problem_information>
+                  <estimation number="1" type="1">
+                    <estimation_method>FOCE</estimation_method>
+                    <termination_status>0</termination_status>
+                    <etashrink>
+                      <row rname="ETA(1)">
+                        <col cname="ETA(1)">8.5</col>
+                      </row>
+                    </etashrink>
+                    <final_objective_function>-800.0</final_objective_function>
+                    <omega>
+                      <row rname="ETA(1)">
+                        <col cname="ETA(1)">0.05</col>
+                      </row>
+                    </omega>
+                  </estimation>
+                </problem>
+              </nonmem>
+              <stop_datetime>2024-01-15T10:35:00</stop_datetime>
+            </output>
+            """;
+
+        var run = new NonmemXmlImporter().ImportXml(xml, sourcePath: "run3.xml");
+        var omega = Assert.Single(run.Estimations[0].Parameters, p => p.Kind == ParameterKind.Omega);
+        Assert.Equal(8.5, omega.Shrinkage, precision: 2);
+    }
+
+    [Fact]
+    public void Import_InlineXml_SimulationRunHasNoEstimations()
+    {
+        var xml = """
+            <?xml version="1.0"?>
+            <output>
+              <start_datetime>2024-01-15T10:30:00</start_datetime>
+              <control_stream></control_stream>
+              <nmtran></nmtran>
+              <nonmem version="7.4.4">
+                <license_information></license_information>
+                <program_information></program_information>
+                <problem number="1" subproblem="0" superproblem1="0" iteration1="0" superproblem2="0" iteration2="0">
+                  <problem_title></problem_title>
+                  <problem_information></problem_information>
+                  <simulation_information>SIMULATION</simulation_information>
+                </problem>
+              </nonmem>
+              <stop_datetime>2024-01-15T10:35:00</stop_datetime>
+            </output>
+            """;
+
+        var run = new NonmemXmlImporter().ImportXml(xml, sourcePath: "sim1.xml");
+        Assert.Empty(run.Estimations);
+        Assert.Equal("1", run.RunNo);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+```
+dotnet test tests/Census.Tests/ --filter "NonmemXmlImporterTests" --logger "console;verbosity=normal"
+```
+
+Expected: compile error or `NotImplementedException` for most tests.
+
+---
+
+## Task 3: Implement NonmemXmlImporter
+
+**Files:**
+- Modify: `src/Census.Import/NonmemXmlImporter.cs`
+
+- [ ] **Step 1: Replace stub with full implementation**
+
+Replace the entire contents of `src/Census.Import/NonmemXmlImporter.cs`:
+
+```csharp
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Xml.Linq;
+using Census.Domain;
+
+namespace Census.Import;
+
+/// <summary>
+/// Imports NONMEM 7.2+ XML output files into <see cref="Run"/> domain objects.
+/// Parses by local element/attribute name so it is robust to the nm: namespace prefix
+/// used in real NONMEM 7.3+ output and to bare-name older output.
+/// </summary>
+public sealed class NonmemXmlImporter : IRunImporter
+{
+    public bool CanImport(string sourcePath) =>
+        sourcePath.EndsWith(".xml", StringComparison.OrdinalIgnoreCase);
+
+    public Run Import(string sourcePath)
+    {
+        var xml = File.ReadAllText(sourcePath);
+        var run = ImportXml(xml, sourcePath);
+        var md5 = ComputeMd5(sourcePath);
+        return run with
+        {
+            Files = [new FileArtifact { Role = "output", Path = sourcePath, Md5 = md5 }],
+        };
+    }
+
+    /// <summary>Parse from an XML string. Exposed for testing without disk I/O.</summary>
+    public Run ImportXml(string xml, string sourcePath)
+    {
+        var doc = XDocument.Parse(xml);
+        var root = doc.Root!;
+
+        var nonmem = El(root, "nonmem");
+        var firstProblem = nonmem is not null ? El(nonmem, "problem") : null;
+
+        var obsRecs = ParseInt(Attr(El(firstProblem, "problem_options"), "data_nobs"));
+        var individuals = ParseInt(Attr(El(firstProblem, "problem_options"), "data_nind"));
+
+        var estimations = firstProblem is not null
+            ? ParseEstimations(firstProblem)
+            : [];
+
+        var runNo = DeriveRunNo(sourcePath);
+
+        return new Run
+        {
+            RunNo = runNo,
+            IRunNo = int.TryParse(runNo, NumberStyles.Integer, CultureInfo.InvariantCulture, out var n) ? n : 0,
+            ObsRecs = obsRecs,
+            Individuals = individuals,
+            Estimations = estimations,
+            Files = [],
+        };
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static List<Estimation> ParseEstimations(XElement problem)
+    {
+        var result = new List<Estimation>();
+
+        // Both "estimation" and "sir_estimation" (NONMEM 7.6+) follow the same sub-structure.
+        foreach (var estEl in problem.Elements()
+            .Where(e => e.Name.LocalName is "estimation" or "sir_estimation"))
+        {
+            var number = ParseInt(Attr(estEl, "number")) ?? 0;
+            var method = El(estEl, "estimation_method")?.Value?.Trim();
+            var ofv = ParseDouble(El(estEl, "final_objective_function")?.Value);
+            var conditionNumber = ParseConditionNumber(El(estEl, "covariance_status"));
+
+            // Shrinkage: prefer etashrinksd (7.3+, SD-based) over etashrink (7.2 legacy).
+            var etaShrinkEl = El(estEl, "etashrinksd") ?? El(estEl, "etashrink");
+            var epsShrinkEl = El(estEl, "epsshrinksd") ?? El(estEl, "epsshrink");
+
+            var thetas = ParseThetas(El(estEl, "theta"), El(estEl, "thetase"));
+            var omegas = ParseMatrix(ParameterKind.Omega, El(estEl, "omega"), El(estEl, "omegase"), etaShrinkEl);
+            var sigmas = ParseMatrix(ParameterKind.Sigma, El(estEl, "sigma"), El(estEl, "sigmase"), epsShrinkEl);
+
+            var warnings = ParseWarnings(
+                El(estEl, "termination_status"),
+                El(estEl, "termination_information"));
+
+            result.Add(new Estimation
+            {
+                Number = number,
+                Method = method,
+                Ofv = ofv,
+                ConditionNumber = conditionNumber,
+                Parameters = [.. thetas, .. omegas, .. sigmas],
+                Warnings = warnings,
+            });
+        }
+
+        return result;
+    }
+
+    private static List<Parameter> ParseThetas(XElement? thetaEl, XElement? thetaseEl)
+    {
+        if (thetaEl is null)
+        {
+            return [];
+        }
+
+        var estimates = Els(thetaEl, "val").ToList();
+        var ses = thetaseEl is not null ? Els(thetaseEl, "val").ToList() : [];
+
+        var result = new List<Parameter>(estimates.Count);
+        for (var i = 0; i < estimates.Count; i++)
+        {
+            result.Add(new Parameter
+            {
+                Kind = ParameterKind.Theta,
+                Index = i + 1,
+                Label = Attr(estimates[i], "name")?.Trim(),
+                Estimate = ParseDouble(estimates[i].Value),
+                StandardError = i < ses.Count ? ParseDouble(ses[i].Value) : null,
+            });
+        }
+
+        return result;
+    }
+
+    private static List<Parameter> ParseMatrix(
+        ParameterKind kind,
+        XElement? matEl,
+        XElement? seEl,
+        XElement? shrinkEl)
+    {
+        if (matEl is null)
+        {
+            return [];
+        }
+
+        // Lower-triangular matrix: row i has i cols; diagonal = last col of each row.
+        var rows = Els(matEl, "row").ToList();
+        var seRows = seEl is not null ? Els(seEl, "row").ToList() : [];
+        var shrinkRows = shrinkEl is not null ? Els(shrinkEl, "row").ToList() : [];
+
+        var result = new List<Parameter>(rows.Count);
+        for (var i = 0; i < rows.Count; i++)
+        {
+            var diagonalCol = Els(rows[i], "col").LastOrDefault();
+            var diagonalSe = i < seRows.Count
+                ? Els(seRows[i], "col").LastOrDefault()
+                : null;
+            // Shrinkage tables have one value per row (one per eta/eps).
+            var shrinkCol = i < shrinkRows.Count
+                ? Els(shrinkRows[i], "col").FirstOrDefault()
+                : null;
+
+            result.Add(new Parameter
+            {
+                Kind = kind,
+                Index = i + 1,
+                Label = Attr(rows[i], "rname")?.Trim(),
+                Estimate = diagonalCol is not null ? ParseDouble(diagonalCol.Value) : null,
+                StandardError = diagonalSe is not null ? ParseDouble(diagonalSe.Value) : null,
+                Shrinkage = shrinkCol is not null ? ParseDouble(shrinkCol.Value) : null,
+            });
+        }
+
+        return result;
+    }
+
+    private static double? ParseConditionNumber(XElement? covStatusEl)
+    {
+        if (covStatusEl is null)
+        {
+            return null;
+        }
+
+        var minVal = ParseDouble(Attr(covStatusEl, "mineigenvalue"));
+        var maxVal = ParseDouble(Attr(covStatusEl, "maxeigenvalue"));
+
+        if (minVal is null || maxVal is null || minVal == 0.0)
+        {
+            return null;
+        }
+
+        return maxVal / minVal;
+    }
+
+    private static List<string> ParseWarnings(XElement? statusEl, XElement? infoEl)
+    {
+        if (statusEl is null)
+        {
+            return [];
+        }
+
+        if (!int.TryParse(statusEl.Value.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var status) ||
+            status == 0)
+        {
+            return [];
+        }
+
+        var text = infoEl?.Value?.Trim();
+        return string.IsNullOrEmpty(text) ? [] : [text];
+    }
+
+    private static string DeriveRunNo(string sourcePath)
+    {
+        var stem = Path.GetFileNameWithoutExtension(sourcePath);
+        // Strip leading "run" prefix (case-insensitive) if present, e.g. "run27" -> "27".
+        if (stem.StartsWith("run", StringComparison.OrdinalIgnoreCase) && stem.Length > 3)
+        {
+            stem = stem[3..];
+        }
+
+        return stem;
+    }
+
+    private static string ComputeMd5(string filePath)
+    {
+        var bytes = File.ReadAllBytes(filePath);
+        var hash = MD5.HashData(bytes);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    // Select by local name — transparent to nm: prefix used in real NONMEM output.
+    private static XElement? El(XContainer? parent, string localName) =>
+        parent?.Elements().FirstOrDefault(e => e.Name.LocalName == localName);
+
+    private static IEnumerable<XElement> Els(XContainer parent, string localName) =>
+        parent.Elements().Where(e => e.Name.LocalName == localName);
+
+    // Attribute lookup by local name (real NONMEM uses nm:name="..." on attributes too).
+    private static string? Attr(XElement? el, string localName) =>
+        el?.Attributes().FirstOrDefault(a => a.Name.LocalName == localName)?.Value;
+
+    private static double? ParseDouble(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return double.TryParse(value.Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out var d)
+            ? d
+            : null;
+    }
+
+    private static int? ParseInt(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return int.TryParse(value.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var i)
+            ? i
+            : null;
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+```
+dotnet test tests/Census.Tests/ --filter "NonmemXmlImporterTests" --logger "console;verbosity=normal"
+```
+
+Expected: all tests pass.
+
+---
+
+## Task 4: Run the full suite and commit
+
+- [ ] **Step 1: Run all tests**
+
+```
+dotnet test tests/Census.Tests/ --logger "console;verbosity=normal"
+```
+
+Expected: all tests green (previously passing `RunTests` and `SqliteProjectStoreTests` must remain green).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add tests/Census.Tests/fixtures/run27.xml \
+        tests/Census.Tests/Census.Tests.csproj \
+        tests/Census.Tests/NonmemXmlImporterTests.cs \
+        src/Census.Import/NonmemXmlImporter.cs
+git commit -m "feat: implement Phase 3 NONMEM XML importer with fixture tests"
+```
+
+---
+
+## Self-Review
+
+### Spec coverage
+
+| Requirement (from IMPLEMENTATION_PLAN.md §Phase 3) | Covered by |
+|---|---|
+| Schema-aware traversal into domain objects | `ParseEstimations`, `ParseThetas`, `ParseMatrix` in Task 3 |
+| MD5 via `System.Security.Cryptography` | `ComputeMd5` in Task 3 |
+| File discovery (source file as artifact) | `Import()` sets `Files` with the source path |
+| `XmlSchemaClassGenerator` | **Deliberately skipped** — XDocument by local name is simpler, equally correct, and more robust to namespace variations in real NONMEM output. |
+| Regression-test against fixtures | `NonmemXmlImporterTests` + `run27.xml` fixture in Tasks 1–2 |
+| `ObsRecs`/`Individuals` (7.6+ only) | Extracted from `problem_options/@data_nobs` / `@data_nind`; null for 7.2 files that lack `problem_options` |
+| 7.6 `etashrinksd`/`epsshrinksd` + 7.2 `etashrink`/`epsshrink` fallback | Handled in `ParseEstimations` with `??` fallback |
+| `sir_estimation` (NONMEM 7.6+) | Included in the LINQ filter alongside `estimation` |
+| Namespace: `nm:` prefix on elements and attributes | Handled via `Name.LocalName` and `Attributes().FirstOrDefault(a => a.Name.LocalName == x)` |
+
+### What's deferred (out of scope for this phase)
+
+- **Multiple estimations** — the parser handles them (`ParseEstimations` loops), but no fixture covers it. Add a second fixture or inline test when a multi-estimation run becomes available.
+- **PsN import** — Phase 5.
+- **Listing parser** — Phase 5.
+- **`ObsRecs` / `Individuals`** — not present in NONMEM XML; to be populated by the listing parser or PsN metadata in Phase 5.
+- **`DOfv`** — cross-run computation, handled by storage/reporting layer.

--- a/output.dtd
+++ b/output.dtd
@@ -1,0 +1,327 @@
+<!ELEMENT nm:output ( nm:start_datetime | nm:control_stream | nm:nmtran | nm:nonmem | nm:stop_datetime  | nm:total_cputime )*>
+<!ATTLIST nm:output xmlns:nm CDATA #IMPLIED xmlns:xsi CDATA #IMPLIED xsi:schemaLocation CDATA #IMPLIED>
+<!ELEMENT nm:start_datetime (#PCDATA)>
+<!ELEMENT nm:stop_datetime (#PCDATA)>
+<!ELEMENT nm:total_cputime (#PCDATA)>
+<!ELEMENT nm:control_stream (#PCDATA)>
+<!ELEMENT nm:nmtran (#PCDATA)>
+<!ELEMENT nm:nonmem (nm:problem | nm:license_information | nm:program_information  | nm:theta_lb | nm:theta_in | nm:theta_ub 
+ | nm:olkjdf | nm:ovarf | nm:slkjdf | nm:svarf | nm:ttdf  )*>
+<!ATTLIST nm:nonmem nm:version CDATA #IMPLIED>
+<!ELEMENT nm:license_information (#PCDATA)>
+<!ELEMENT nm:program_information (#PCDATA)>
+<!ELEMENT nm:problem (nm:problem_title | nm:problem_information | nm:problem_options 
+ | nm:theta_lb | nm:theta_in | nm:theta_ub | nm:chain_record 
+ | nm:parallel_chain_record  | nm:parallel_sim 
+ | nm:simulation_information | nm:sim_info | nm:sim_elapsed_time | nm:estimation | nm:table | nm:scatter | nm:post_process_times
+ | nm:parallel_sir | nm:sir_estimation | nm:parallel_wres  | nm:parallel_fnleta )*>
+<!ATTLIST nm:problem nm:number CDATA #IMPLIED nm:subproblem CDATA  #IMPLIED nm:superproblem1 CDATA  #IMPLIED nm:iteration1 CDATA  #IMPLIED nm:superproblem2 CDATA  #IMPLIED nm:iteration2 CDATA #IMPLIED >
+<!ELEMENT nm:post_process_times (nm:post_elapsed_time | nm:finaloutput_elapsed_time )*>
+<!ELEMENT nm:problem_title (#PCDATA)>
+<!ELEMENT nm:problem_information (#PCDATA)>
+<!ELEMENT nm:problem_options EMPTY>
+<!ATTLIST nm:problem_options nm:data_checkout_run CDATA #IMPLIED nm:data_previous CDATA #IMPLIED nm:data_unit CDATA #IMPLIED
+ nm:data_rewind CDATA #IMPLIED  nm:data_fdatacsv CDATA #IMPLIED nm:data_nrec CDATA #IMPLIED nm:data_nitems CDATA #IMPLIED nm:data_id CDATA #IMPLIED
+ nm:data_l2 CDATA #IMPLIED nm:data_dv CDATA #IMPLIED nm:data_mdv CDATA #IMPLIED nm:data_mrg CDATA #IMPLIED
+ nm:data_raw CDATA #IMPLIED nm:data_rpt CDATA #IMPLIED nm:data_sub_array1 CDATA #IMPLIED nm:data_sub_array2 CDATA #IMPLIED
+ nm:data_sub_array3 CDATA #IMPLIED nm:data_pred_indices CDATA #IMPLIED nm:data_format CDATA #IMPLIED  nm:data_spcformat CDATA #IMPLIED
+ nm:data_nobs CDATA #IMPLIED nm:data_nind CDATA #IMPLIED nm:data_mdv100 CDATA #IMPLIED nm:msfi_rescaled CDATA #IMPLIED nm:nthetat CDATA #IMPLIED
+ nm:theta_bound_test_omitted CDATA #IMPLIED 
+ nm:omega_diagdim CDATA #IMPLIED nm:omega_bound_test_omitted CDATA #IMPLIED nm:omega_blockdim CDATA #IMPLIED
+ nm:sigma_diagdim CDATA #IMPLIED nm:sigma_bound_test_omitted CDATA #IMPLIED nm:sigma_blockdim CDATA #IMPLIED
+ nm:nfn_initial CDATA #IMPLIED nm:sim_omitted CDATA #IMPLIED nm:sim_obj_evaluated CDATA #IMPLIED
+ nm:sim_rewind CDATA #IMPLIED nm:sim_with_initial_estimate CDATA #IMPLIED nm:sim_with_final_estimate CDATA #IMPLIED nm:sim_with_prior CDATA #IMPLIED 
+ nm:sim_ranmethod CDATA #IMPLIED nm:sim_supreset CDATA #IMPLIED  nm:sim_clockseed CDATA #IMPLIED
+ nm:sim_newran CDATA #IMPLIED nm:sim_etader_order_max CDATA #IMPLIED 
+ nm:sim_source_eps CDATA #IMPLIED nm:sim_ttdf CDATA #IMPLIED 
+ nm:sim_seed1_01 CDATA #IMPLIED nm:sim_seed2_01 CDATA #IMPLIED nm:sim_dist_01 CDATA #IMPLIED 
+ nm:sim_seed1_02 CDATA #IMPLIED nm:sim_seed2_02 CDATA #IMPLIED nm:sim_dist_02 CDATA #IMPLIED 
+ nm:sim_seed1_03 CDATA #IMPLIED nm:sim_seed2_03 CDATA #IMPLIED nm:sim_dist_03 CDATA #IMPLIED 
+ nm:sim_seed1_04 CDATA #IMPLIED nm:sim_seed2_04 CDATA #IMPLIED nm:sim_dist_04 CDATA #IMPLIED 
+ nm:sim_seed1_05 CDATA #IMPLIED nm:sim_seed2_05 CDATA #IMPLIED nm:sim_dist_05 CDATA #IMPLIED 
+ nm:sim_seed1_06 CDATA #IMPLIED nm:sim_seed2_06 CDATA #IMPLIED nm:sim_dist_06 CDATA #IMPLIED 
+ nm:sim_seed1_07 CDATA #IMPLIED nm:sim_seed2_07 CDATA #IMPLIED nm:sim_dist_07 CDATA #IMPLIED 
+ nm:sim_seed1_08 CDATA #IMPLIED nm:sim_seed2_08 CDATA #IMPLIED nm:sim_dist_08 CDATA #IMPLIED 
+ nm:sim_seed1_09 CDATA #IMPLIED nm:sim_seed2_09 CDATA #IMPLIED nm:sim_dist_09 CDATA #IMPLIED 
+ nm:sim_seed1_10 CDATA #IMPLIED nm:sim_seed2_10 CDATA #IMPLIED nm:sim_dist_10 CDATA #IMPLIED 
+ nm:sim_subprob CDATA #IMPLIED
+ nm:nonpar_omitted CDATA #IMPLIED
+ nm:nonpar_estim CDATA #IMPLIED
+ nm:nonpar_density_recompute CDATA #IMPLIED nm:nonpar_marginal_cum CDATA #IMPLIED nm:nonpar_pop_etas CDATA #IMPLIED
+ nm:nonpar_msfoutput CDATA #IMPLIED nm:nonpar_bootstrap CDATA #IMPLIED nm:nonpar_support_nodes CDATA #IMPLIED
+ nm:nonpar_stratcol CDATA #IMPLIED nm:nonpar_stratfcol CDATA #IMPLIED
+ nm:nonpar_expand CDATA #IMPLIED nm:nonpar_nsuppe CDATA #IMPLIED nm:cov_omitted CDATA #IMPLIED
+ nm:cov_matrix CDATA #IMPLIED nm:cov_rmatrix_print CDATA #IMPLIED
+ nm:cov_smatrix_print CDATA #IMPLIED nm:cov_eigen_print CDATA #IMPLIED nm:cov_special CDATA #IMPLIED nm:cov_compressed CDATA #IMPLIED
+ nm:cov_slow_gradient CDATA #IMPLIED nm:cov_siglocov CDATA #IMPLIED 
+ nm:cov_sirsample CDATA #IMPLIED  nm:cov_sirniter CDATA #IMPLIED  nm:cov_sircenter CDATA #IMPLIED
+ nm:cov_capcorr CDATA #IMPLIED  nm:cov_sirminwt CDATA #IMPLIED  nm:cov_sirmaxwt CDATA #IMPLIED
+ nm:cov_iaccept CDATA #IMPLIED nm:cov_iacceptl CDATA #IMPLIED nm:cov_df CDATA #IMPLIED
+ nm:cov_pfcond CDATA #IMPLIED  nm:cov_precond CDATA #IMPLIED   nm:cov_pretype CDATA #IMPLIED  nm:cov_fposdef CDATA #IMPLIED 
+ nm:cov_posdef CDATA #IMPLIED 
+ nm:cov_thbnd CDATA #IMPLIED  nm:cov_sirthbnd CDATA #IMPLIED  nm:cov_preconds CDATA #IMPLIED 
+ nm:cov_file CDATA #IMPLIED nm:cov_format CDATA #IMPLIED nm:cov_print CDATA #IMPLIED nm:cov_seed CDATA #IMPLIED 
+ nm:cov_clockseed CDATA #IMPLIED nm:cov_ranmethod CDATA #IMPLIED
+ nm:cov_siglcov CDATA #IMPLIED nm:cov_tol CDATA #IMPLIED
+ nm:cov_atol CDATA #IMPLIED nm:cov_nofcov CDATA #IMPLIED nm:cov_resume CDATA #IMPLIED nm:tab_omitted CDATA #IMPLIED
+ nm:cov_knuthsumoff CDATA #IMPLIED nm:cov_cholroff CDATA #IMPLIED
+ nm:tab_number CDATA #IMPLIED nm:tab_seed CDATA #IMPLIED
+ nm:tab_clockseed CDATA #IMPLIED nm:tab_npdtype CDATA #IMPLIED nm:tab_interptype CDATA #IMPLIED
+ nm:tab_ranmethod CDATA #IMPLIED nm:tab_esample CDATA #IMPLIED
+ nm:tab_fixedetas_01 CDATA #IMPLIED  nm:tab_fixedetas_02 CDATA #IMPLIED  nm:tab_fixedetas_03 CDATA #IMPLIED 
+ nm:tab_fixedetas_04 CDATA #IMPLIED  nm:tab_fixedetas_05 CDATA #IMPLIED  nm:tab_fixedetas_06 CDATA #IMPLIED 
+ nm:tab_fixedetas_07 CDATA #IMPLIED  nm:tab_fixedetas_08 CDATA #IMPLIED  nm:tab_fixedetas_09 CDATA #IMPLIED 
+ nm:tab_fixedetas_10 CDATA #IMPLIED 
+ nm:tab_wres CDATA #IMPLIED nm:scatter_omitted CDATA #IMPLIED nm:scatter_number CDATA #IMPLIED
+ nm:pred_advan CDATA #IMPLIED nm:pred_evid CDATA #IMPLIED nm:pred_time CDATA #IMPLIED nm:pred_amt CDATA #IMPLIED
+ nm:pred_rate CDATA #IMPLIED nm:pred_ss CDATA #IMPLIED nm:pred_ii CDATA #IMPLIED nm:pred_addl CDATA #IMPLIED
+ nm:pred_cmt CDATA #IMPLIED nm:pred_pcmt CDATA #IMPLIED nm:pred_call CDATA #IMPLIED nm:pred_cont CDATA #IMPLIED>
+<!ELEMENT nm:olkjdf (nm:val)*>
+<!ELEMENT nm:ovarf (nm:val)*>
+<!ELEMENT nm:slkjdf (nm:val)*>
+<!ELEMENT nm:svarf (nm:val)*>
+<!ELEMENT nm:ttdf (nm:val)*>
+<!ELEMENT nm:theta_lb (nm:val)*>
+<!ELEMENT nm:theta_in (nm:val)*>
+<!ELEMENT nm:theta_ub (nm:val)*>
+<!ELEMENT nm:chain_record (nm:chain_record_information | nm:chain_record_options)*>
+<!ELEMENT nm:chain_record_information (#PCDATA)>
+<!ELEMENT nm:chain_record_options EMPTY>
+<!ATTLIST nm:chain_record_options
+ nm:notitle CDATA #IMPLIED nm:nolabel CDATA #IMPLIED
+ nm:format CDATA #IMPLIED
+ nm:order CDATA #IMPLIED nm:ctype CDATA #IMPLIED  
+ nm:seed CDATA #IMPLIED nm:clockseed CDATA #IMPLIED
+ nm:nsample CDATA #IMPLIED  nm:select CDATA #IMPLIED  nm:file CDATA #IMPLIED  nm:dfs CDATA #IMPLIED 
+ nm:isample CDATA #IMPLIED nm:isampend CDATA #IMPLIED nm:ranmethod CDATA #IMPLIED
+ nm:iaccept CDATA #IMPLIED nm:df CDATA #IMPLIED>
+<!ELEMENT nm:simulation_information (#PCDATA)>
+<!ELEMENT nm:sim_elapsed_time (#PCDATA)>
+<!ELEMENT nm:sim_info EMPTY>
+<!ATTLIST nm:sim_info nm:superproblem1 CDATA #IMPLIED nm:iteration1 CDATA #IMPLIED nm:superproblem2 CDATA #IMPLIED
+ nm:iteration2 CDATA #IMPLIED nm:problem CDATA #IMPLIED nm:subproblem CDATA #IMPLIED
+ nm:sim_bootstrap CDATA #IMPLIED  nm:sim_bootstrap_replace CDATA #IMPLIED  nm:sim_stratcol CDATA #IMPLIED  nm:sim_stratfcol CDATA #IMPLIED 
+ nm:sim_seed1_01 CDATA #IMPLIED nm:sim_seed2_01 CDATA #IMPLIED 
+ nm:sim_seed1_02 CDATA #IMPLIED nm:sim_seed2_02 CDATA #IMPLIED 
+ nm:sim_seed1_03 CDATA #IMPLIED nm:sim_seed2_03 CDATA #IMPLIED 
+ nm:sim_seed1_04 CDATA #IMPLIED nm:sim_seed2_04 CDATA #IMPLIED 
+ nm:sim_seed1_05 CDATA #IMPLIED nm:sim_seed2_05 CDATA #IMPLIED 
+ nm:sim_seed1_06 CDATA #IMPLIED nm:sim_seed2_06 CDATA #IMPLIED 
+ nm:sim_seed1_07 CDATA #IMPLIED nm:sim_seed2_07 CDATA #IMPLIED 
+ nm:sim_seed1_08 CDATA #IMPLIED nm:sim_seed2_08 CDATA #IMPLIED 
+ nm:sim_seed1_09 CDATA #IMPLIED nm:sim_seed2_09 CDATA #IMPLIED 
+ nm:sim_seed1_10 CDATA #IMPLIED nm:sim_seed2_10 CDATA #IMPLIED>
+<!ELEMENT nm:parallel_chain_record EMPTY>
+<!ATTLIST nm:parallel_chain_record nm:parafile CDATA #IMPLIED nm:protocol CDATA  #IMPLIED nm:nodes CDATA #IMPLIED >
+<!ELEMENT nm:parallel_sim EMPTY>
+<!ATTLIST nm:parallel_sim nm:parafile CDATA #IMPLIED nm:protocol CDATA  #IMPLIED nm:nodes CDATA #IMPLIED >
+<!ELEMENT nm:estimation ( nm:parallel_chain_est | nm:parallel_est | nm:table_series 
+          | nm:estimation_method | nm:estimation_title | nm:estimation_information | nm:estimation_options 
+          | nm:monitor | nm:estimation_burnin_time | nm:estimation_elapsed_time | nm:optd_elapsed_time | nm:parallel_cov 
+          | nm:parallel_fnleta | nm:parallel_nonpar | nm:parallel_nonparo
+          | nm:nonpar_elapsed_time | nm:nonpar_elapsed_timeb | nm:parallel_wres
+          | nm:termination_status 
+          | nm:termination_nfuncevals | nm:termination_sigdigits | nm:termination_information | nm:termination_txtmsg 
+          | nm:etabar | nm:etabarse | nm:etabarpval | nm:etashrinksd | nm:ebvshrinksd 
+          | nm:etabarn | nm:etashrinkvr | nm:ebvshrinkvr | nm:relativeinf 
+          | nm:epsshrinksd | nm:epsshrinkvr | nm:covariance_information | nm:covariance_status | nm:covariance_elapsed_time
+          | nm:final_objective_function_text | nm:final_objective_function | nm:final_objective_function_std 
+          | nm:cnv_objective_function | nm:cnv_objective_function_std 
+          | nm:theta | nm:omega | nm:sigma | nm:omegac | nm:sigmac | nm:thetase | nm:omegase | nm:sigmase
+          | nm:omegacse | nm:sigmacse | nm:covariance | nm:correlation | nm:invcovariance | nm:eigenvalues | nm:np_objective_function
+          | nm:rmatrix | nm:smatrix | nm:thetanp | nm:exnpeta |  nm:covnpeta | nm:covnpetac | nm:omeganp | nm:omeganpc )*>
+<!ATTLIST nm:estimation nm:number CDATA  #IMPLIED nm:type CDATA  #IMPLIED>
+<!ELEMENT nm:sir_estimation ( nm:table_series | nm:estimation_method | nm:estimation_title | nm:monitor 
+          | nm:estimation_elapsed_time | nm:termination_status | nm:termination_information 
+          | nm:final_objective_function_text | nm:final_objective_function | nm:final_objective_function_std 
+          | nm:cnv_objective_function | nm:cnv_objective_function_std 
+          | nm:theta | nm:omega | nm:sigma | nm:omegac | nm:sigmac | nm:thetase | nm:omegase | nm:sigmase
+          | nm:omegacse | nm:sigmacse | nm:covariance | nm:correlation | nm:invcovariance | nm:eigenvalues 
+          | nm:rmatrix | nm:smatrix )*>
+<!ATTLIST nm:sir_estimation nm:number CDATA  #IMPLIED nm:type CDATA  #IMPLIED>
+<!ELEMENT nm:parallel_chain_est EMPTY>
+<!ATTLIST nm:parallel_chain_est nm:parafile CDATA #IMPLIED nm:protocol CDATA #IMPLIED nm:nodes CDATA #IMPLIED >
+<!ELEMENT nm:parallel_est EMPTY>
+<!ATTLIST nm:parallel_est nm:parafile CDATA #IMPLIED nm:protocol CDATA #IMPLIED nm:nodes CDATA #IMPLIED >
+<!ELEMENT nm:parallel_sir EMPTY>
+<!ATTLIST nm:parallel_sir nm:parafile CDATA #IMPLIED nm:protocol CDATA #IMPLIED nm:nodes CDATA #IMPLIED >
+<!ELEMENT nm:table_series (#PCDATA)>
+<!ELEMENT nm:estimation_method (#PCDATA)>
+<!ELEMENT nm:estimation_title (#PCDATA)>
+<!ELEMENT nm:estimation_information (#PCDATA)>
+<!ELEMENT nm:estimation_options EMPTY>
+<!ATTLIST nm:estimation_options nm:estim_omitted CDATA #IMPLIED nm:analysis_type CDATA #IMPLIED nm:posthoc CDATA #IMPLIED
+ nm:saddle_reset CDATA #IMPLIED nm:saddle_hess CDATA #IMPLIED
+ nm:fo_model_app CDATA #IMPLIED nm:slow_gradient CDATA #IMPLIED nm:cond_estim CDATA #IMPLIED nm:etas_fixed_to_zero CDATA #IMPLIED
+ nm:epseta_interaction CDATA #IMPLIED nm:centered_eta CDATA #IMPLIED 
+ nm:laplace CDATA #IMPLIED nm:numerical_2nd_der CDATA #IMPLIED nm:stieltjes CDATA #IMPLIED
+ nm:nfractiles CDATA #IMPLIED nm:ndirections CDATA #IMPLIED nm:leftpoint CDATA #IMPLIED
+ nm:rightpoint CDATA #IMPLIED nm:predflag CDATA #IMPLIED nm:maxfn CDATA #IMPLIED
+ nm:nsig CDATA #IMPLIED nm:msfo CDATA #IMPLIED nm:conv_repeat CDATA #IMPLIED nm:conv_repeat1 CDATA #IMPLIED
+ nm:conv_repeat2 CDATA #IMPLIED nm:abort CDATA #IMPLIED nm:objsort CDATA #IMPLIED 
+ nm:numder CDATA #IMPLIED nm:optmap CDATA #IMPLIED nm:etader CDATA #IMPLIED nm:mceta CDATA #IMPLIED
+ nm:siglo CDATA #IMPLIED nm:sigl CDATA #IMPLIED nm:notitle CDATA #IMPLIED nm:nolabel CDATA #IMPLIED
+ nm:noprior CDATA #IMPLIED nm:nocov CDATA #IMPLIED nm:dercont CDATA #IMPLIED nm:atol CDATA #IMPLIED
+ nm:fnleta CDATA #IMPLIED nm:etastype CDATA #IMPLIED nm:noninfeta CDATA #IMPLIED nm:format CDATA #IMPLIED
+ nm:order CDATA #IMPLIED nm:ctype CDATA #IMPLIED nm:estimation_method CDATA #IMPLIED 
+ nm:mum CDATA #IMPLIED nm:grd CDATA #IMPLIED nm:auto CDATA #IMPLIED
+ nm:cinterval CDATA #IMPLIED nm:citer CDATA #IMPLIED nm:calpha CDATA #IMPLIED nm:thin CDATA #IMPLIED 
+ nm:nburn CDATA #IMPLIED nm:niter CDATA #IMPLIED nm:constrain CDATA #IMPLIED nm:seed CDATA #IMPLIED  nm:clockseed CDATA #IMPLIED
+ nm:level CDATA #IMPLIED  nm:anneal CDATA #IMPLIED 
+ nm:nsample CDATA #IMPLIED  nm:select CDATA #IMPLIED  nm:file CDATA #IMPLIED  nm:dfs CDATA #IMPLIED 
+ nm:isample CDATA #IMPLIED nm:isampend CDATA #IMPLIED nm:ranmethod CDATA #IMPLIED nm:eonly CDATA #IMPLIED
+ nm:iscale_min CDATA #IMPLIED nm:iscale_max CDATA #IMPLIED nm:iaccept CDATA #IMPLIED  nm:iacceptl CDATA #IMPLIED nm:df CDATA #IMPLIED
+ nm:mapiter CDATA #IMPLIED  nm:mapiters CDATA #IMPLIED nm:mapinter CDATA #IMPLIED nm:mapcov CDATA #IMPLIED nm:stdobj CDATA #IMPLIED nm:isample_m1 CDATA #IMPLIED
+ nm:grdq CDATA #IMPLIED nm:nuts_type CDATA #IMPLIED nm:massreset CDATA #IMPLIED nm:nuts_mass CDATA #IMPLIED
+ nm:bionly CDATA #IMPLIED  nm:bootdata CDATA #IMPLIED 
+ nm:kappa CDATA #IMPLIED nm:ikappa CDATA #IMPLIED nm:nuts_gamma CDATA #IMPLIED nm:igamma CDATA #IMPLIED 
+ nm:nuts_stepiter CDATA #IMPLIED nm:nuts_stepinter CDATA #IMPLIED  
+ nm:nuts_delta CDATA #IMPLIED nm:idelta CDATA #IMPLIED nm:madapt CDATA #IMPLIED nm:imadapt CDATA #IMPLIED
+ nm:ttdf CDATA #IMPLIED nm:olkjdf CDATA #IMPLIED  nm:ovarf CDATA #IMPLIED nm:slkjdf CDATA #IMPLIED  nm:svarf CDATA #IMPLIED
+ nm:nuts_transform CDATA #IMPLIED 
+ nm:tpu CDATA #IMPLIED 
+ nm:knuthsumoff CDATA #IMPLIED nm:stepiter CDATA #IMPLIED  nm:stepinter CDATA #IMPLIED nm:nuts_base CDATA #IMPLIED 
+ nm:nuts_test CDATA #IMPLIED  nm:nuts_maxdepth CDATA #IMPLIED nm:nuts_init CDATA #IMPLIED 
+ nm:nuts_term CDATA #IMPLIED nm:wishtype CDATA #IMPLIED  nm:lntwopi CDATA #IMPLIED nm:olntwopi CDATA #IMPLIED 
+ nm:priorc CDATA #IMPLIED
+ nm:inuts_transform CDATA #IMPLIED nm:nuts_eparam CDATA #IMPLIED nm:levwt CDATA #IMPLIED
+ nm:levcenter CDATA #IMPLIED  nm:levobjtype CDATA #IMPLIED nm:evalshrink CDATA #IMPLIED 
+ nm:nuts_oparam CDATA #IMPLIED  nm:nuts_sparam CDATA #IMPLIED 
+ nm:nuts_reg CDATA #IMPLIED nm:nuts_cholbnd CDATA #IMPLIED  
+ nm:isample_m1a CDATA #IMPLIED nm:isample_m1b CDATA #IMPLIED nm:isample_m2 CDATA #IMPLIED nm:isample_m3 CDATA #IMPLIED
+ nm:pscale_min CDATA #IMPLIED
+ nm:pscale_max CDATA #IMPLIED nm:paccept CDATA #IMPLIED nm:psample_m1 CDATA #IMPLIED nm:psample_m2 CDATA #IMPLIED
+ nm:psample_m3 CDATA #IMPLIED nm:oaccept CDATA #IMPLIED nm:osample_m1 CDATA #IMPLIED nm:osample_m2 CDATA #IMPLIED nm:osample_m3 CDATA #IMPLIED
+ nm:optd_groupsize CDATA #IMPLIED 
+ nm:optd_ofvtype CDATA #IMPLIED 
+ nm:optd_ofvdimscaled CDATA #IMPLIED 
+ nm:optd_eopt CDATA #IMPLIED 
+ nm:optd_datasim CDATA #IMPLIED 
+ nm:optd_fimtype CDATA #IMPLIED 
+ nm:optd_varcross CDATA #IMPLIED 
+ nm:optd_mode_assess CDATA #IMPLIED 
+ nm:optd_estimation CDATA #IMPLIED 
+ nm:optd_nmincol CDATA #IMPLIED 
+ nm:optd_nmaxcol CDATA #IMPLIED 
+ nm:optd_stratcol CDATA #IMPLIED 
+ nm:optd_stratfcol CDATA #IMPLIED 
+ nm:optd_seed CDATA #IMPLIED  nm:optd_clockseed CDATA #IMPLIED 
+ nm:optd_deselcol_01 CDATA #IMPLIED 
+ nm:optd_deselstratcol_01 CDATA #IMPLIED 
+ nm:optd_deselmincol_01 CDATA #IMPLIED 
+ nm:optd_deselmaxcol_01 CDATA #IMPLIED 
+ nm:optd_deselcol_02 CDATA #IMPLIED 
+ nm:optd_deselstratcol_02 CDATA #IMPLIED 
+ nm:optd_deselmincol_02 CDATA #IMPLIED 
+ nm:optd_deselmaxcol_02 CDATA #IMPLIED 
+ nm:optd_deselcol_03 CDATA #IMPLIED 
+ nm:optd_deselstratcol_03 CDATA #IMPLIED 
+ nm:optd_deselmincol_03 CDATA #IMPLIED 
+ nm:optd_deselmaxcol_03 CDATA #IMPLIED 
+ nm:optd_deselcol_04 CDATA #IMPLIED 
+ nm:optd_deselstratcol_04 CDATA #IMPLIED 
+ nm:optd_deselmincol_04 CDATA #IMPLIED 
+ nm:optd_deselmaxcol_04 CDATA #IMPLIED 
+ nm:optd_deselcol_05 CDATA #IMPLIED 
+ nm:optd_deselstratcol_05 CDATA #IMPLIED 
+ nm:optd_deselmincol_05 CDATA #IMPLIED 
+ nm:optd_deselmaxcol_05 CDATA #IMPLIED 
+ nm:optd_deselcol_06 CDATA #IMPLIED 
+ nm:optd_deselstratcol_06 CDATA #IMPLIED 
+ nm:optd_deselmincol_06 CDATA #IMPLIED 
+ nm:optd_deselmaxcol_06 CDATA #IMPLIED 
+ nm:optd_deselcol_07 CDATA #IMPLIED 
+ nm:optd_deselstratcol_07 CDATA #IMPLIED 
+ nm:optd_deselmincol_07 CDATA #IMPLIED 
+ nm:optd_deselmaxcol_07 CDATA #IMPLIED 
+ nm:optd_deselcol_08 CDATA #IMPLIED 
+ nm:optd_deselstratcol_08 CDATA #IMPLIED 
+ nm:optd_deselmincol_08 CDATA #IMPLIED 
+ nm:optd_deselmaxcol_08 CDATA #IMPLIED 
+ nm:optd_deselcol_09 CDATA #IMPLIED 
+ nm:optd_deselstratcol_09 CDATA #IMPLIED 
+ nm:optd_deselmincol_09 CDATA #IMPLIED 
+ nm:optd_deselmaxcol_09 CDATA #IMPLIED 
+ nm:optd_deselcol_10 CDATA #IMPLIED 
+ nm:optd_deselstratcol_10 CDATA #IMPLIED 
+ nm:optd_deselmincol_10 CDATA #IMPLIED 
+ nm:optd_deselmaxcol_10 CDATA #IMPLIED 
+>
+<!ELEMENT nm:monitor (nm:obj)*>
+<!ELEMENT nm:estimation_burnin_time (#PCDATA)>
+<!ELEMENT nm:estimation_elapsed_time (#PCDATA)>
+<!ELEMENT nm:optd_elapsed_time (#PCDATA)>
+<!ELEMENT nm:nonpar_elapsed_time (#PCDATA)>
+<!ELEMENT nm:nonpar_elapsed_timeb (#PCDATA)>
+<!ELEMENT nm:termination_status (#PCDATA)>
+<!ELEMENT nm:termination_nfuncevals (#PCDATA)>
+<!ELEMENT nm:termination_sigdigits (#PCDATA)>
+<!ELEMENT nm:termination_information (#PCDATA)>
+<!ELEMENT nm:termination_txtmsg (nm:val)*>
+<!ELEMENT nm:etabar (nm:row)*>
+<!ELEMENT nm:etabarse (nm:row)*>
+<!ELEMENT nm:etabarn (nm:row)*>
+<!ELEMENT nm:etabarpval (nm:row)*>
+<!ELEMENT nm:etashrinksd (nm:row)*>
+<!ELEMENT nm:etashrinkvr (nm:row)*>
+<!ELEMENT nm:ebvshrinksd (nm:row)*>
+<!ELEMENT nm:ebvshrinkvr (nm:row)*>
+<!ELEMENT nm:relativeinf (nm:row)*>
+<!ELEMENT nm:epsshrinksd (nm:row)*>
+<!ELEMENT nm:epsshrinkvr (nm:row)*>
+<!ELEMENT nm:parallel_cov EMPTY>
+<!ELEMENT nm:parallel_wres EMPTY>
+<!ELEMENT nm:post_elapsed_time (#PCDATA)>
+<!ELEMENT nm:finaloutput_elapsed_time (#PCDATA)>
+<!ELEMENT nm:parallel_fnleta EMPTY>
+<!ELEMENT nm:parallel_nonpar EMPTY>
+<!ELEMENT nm:parallel_nonparo EMPTY>
+<!ATTLIST nm:parallel_cov nm:parafile CDATA #IMPLIED nm:protocol CDATA  #IMPLIED nm:nodes CDATA #IMPLIED >
+<!ATTLIST nm:parallel_wres nm:parafile CDATA #IMPLIED nm:protocol CDATA  #IMPLIED nm:nodes CDATA #IMPLIED >
+<!ATTLIST nm:parallel_fnleta nm:parafile CDATA #IMPLIED nm:protocol CDATA  #IMPLIED nm:nodes CDATA #IMPLIED >
+<!ATTLIST nm:parallel_nonpar nm:parafile CDATA #IMPLIED nm:protocol CDATA  #IMPLIED nm:nodes CDATA #IMPLIED >
+<!ATTLIST nm:parallel_nonparo nm:parafile CDATA #IMPLIED nm:protocol CDATA  #IMPLIED nm:nodes CDATA #IMPLIED >
+<!ELEMENT nm:covariance_information (#PCDATA)>
+<!ELEMENT nm:covariance_status EMPTY>
+<!ATTLIST nm:covariance_status nm:error CDATA #IMPLIED nm:numnegeigenvalues CDATA  #IMPLIED nm:mineigenvalue CDATA  #IMPLIED nm:maxeigenvalue CDATA  #IMPLIED nm:rms CDATA #IMPLIED >
+<!ELEMENT nm:covariance_elapsed_time (#PCDATA)>
+<!ELEMENT nm:final_objective_function_text (#PCDATA)>
+<!ELEMENT nm:final_objective_function (#PCDATA)>
+<!ELEMENT nm:np_objective_function (#PCDATA)>
+<!ELEMENT nm:final_objective_function_std (#PCDATA)>
+<!ELEMENT nm:cnv_objective_function (#PCDATA)>
+<!ELEMENT nm:cnv_objective_function_std (#PCDATA)>
+<!ELEMENT nm:theta (nm:val)*>
+<!ELEMENT nm:omega (nm:row)*>
+<!ELEMENT nm:sigma (nm:row)*>
+<!ELEMENT nm:omegac (nm:row)*>
+<!ELEMENT nm:sigmac (nm:row)*>
+<!ELEMENT nm:omegacse (nm:row)*>
+<!ELEMENT nm:sigmacse (nm:row)*>
+<!ELEMENT nm:thetase (nm:val)*>
+<!ELEMENT nm:omegase (nm:row)*>
+<!ELEMENT nm:sigmase (nm:row)*>
+<!ELEMENT nm:exnpeta (nm:val)*>
+<!ELEMENT nm:thetanp (nm:val)*>
+<!ELEMENT nm:covnpeta (nm:row)*>
+<!ELEMENT nm:covnpetac (nm:row)*>
+<!ELEMENT nm:omeganp (nm:row)*>
+<!ELEMENT nm:omeganpc (nm:row)*>
+<!ELEMENT nm:covariance (nm:row)*>
+<!ELEMENT nm:correlation (nm:row)*>
+<!ELEMENT nm:invcovariance (nm:row)*>
+<!ELEMENT nm:rmatrix (nm:row)*>
+<!ELEMENT nm:smatrix (nm:row)*>
+<!ELEMENT nm:eigenvalues (nm:val)*>
+<!ELEMENT nm:obj (#PCDATA)>
+<!ATTLIST nm:obj nm:iteration CDATA #IMPLIED nm:effective CDATA #IMPLIED nm:sample CDATA  #IMPLIED nm:fitness CDATA #IMPLIED>
+<!ELEMENT nm:val (#PCDATA)>
+<!ATTLIST nm:val nm:name CDATA #IMPLIED>
+<!ELEMENT nm:row (nm:col)*>
+<!ATTLIST nm:row nm:rname CDATA #IMPLIED>
+<!ELEMENT nm:col (#PCDATA)>
+<!ATTLIST nm:col nm:cname CDATA #IMPLIED>
+<!ELEMENT nm:table (nm:row)*>
+<!ATTLIST nm:table nm:number CDATA #IMPLIED>
+<!ELEMENT nm:scatter (#PCDATA)>
+<!ATTLIST nm:scatter nm:number CDATA  #IMPLIED nm:ord CDATA  #IMPLIED nm:abs CDATA #IMPLIED>

--- a/output.xsd
+++ b/output.xsd
@@ -1,0 +1,769 @@
+<?xml version="1.0" encoding="ASCII"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+targetNamespace="http://namespaces.oreilly.com/xmlnut/address"
+xmlns:nm="http://namespaces.oreilly.com/xmlnut/address"
+elementFormDefault="qualified"
+attributeFormDefault="qualified">
+
+<xs:element name="output">
+  <xs:complexType>
+    <xs:sequence>
+      <xs:element name="start_datetime" type="xs:dateTime"/>
+      <xs:element name="control_stream" type="xs:string"/>
+      <xs:element name="nmtran" type="xs:string"/>
+      <xs:element name="nonmem">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="license_information" type="xs:string"/>
+            <xs:element name="program_information" type="xs:string"/>
+            <xs:element name="olkjdf" minOccurs="0" maxOccurs="1" type="nm:vector"/>
+            <xs:element name="ovarf" minOccurs="0" maxOccurs="1" type="nm:vector"/>
+            <xs:element name="slkjdf" minOccurs="0" maxOccurs="1" type="nm:vector"/>
+            <xs:element name="svarf" minOccurs="0" maxOccurs="1" type="nm:vector"/>
+            <xs:element name="ttdf" minOccurs="0" maxOccurs="1" type="nm:vector"/>
+            <xs:element name="theta_lb" minOccurs="0" maxOccurs="1" type="nm:vector"/>
+            <xs:element name="theta_in" minOccurs="0" maxOccurs="1" type="nm:vector"/>
+            <xs:element name="theta_ub" minOccurs="0" maxOccurs="1" type="nm:vector"/>
+            <xs:element name="problem" minOccurs="0" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="problem_title" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                  <xs:element name="problem_information" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                  <xs:element name="problem_options" minOccurs="0" maxOccurs="1">
+                    <xs:complexType>
+                      <xs:attribute name="data_checkout_run" type="xs:string" use="optional"/>
+                      <xs:attribute name="data_previous" type="xs:string" use="optional"/>
+                      <xs:attribute name="data_unit" type="xs:string" use="optional"/>
+                      <xs:attribute name="data_rewind" type="xs:string" use="optional"/>
+                      <xs:attribute name="data_fdatacsv" type="xs:string" use="optional"/>
+                      <xs:attribute name="data_nrec" type="xs:string" use="optional"/>
+                      <xs:attribute name="data_nitems" type="xs:string" use="optional"/>
+                      <xs:attribute name="data_id" type="xs:string" use="optional"/>
+                      <xs:attribute name="data_l2" type="xs:string" use="optional"/>
+                      <xs:attribute name="data_dv" type="xs:string" use="optional"/>
+                      <xs:attribute name="data_mdv" type="xs:string" use="optional"/>
+                      <xs:attribute name="data_mrg" type="xs:string" use="optional"/>
+                      <xs:attribute name="data_raw" type="xs:string" use="optional"/>
+                      <xs:attribute name="data_rpt" type="xs:string" use="optional"/>
+                      <xs:attribute name="data_sub_array1" type="xs:string" use="optional"/>
+                      <xs:attribute name="data_sub_array2" type="xs:string" use="optional"/>
+                      <xs:attribute name="data_sub_array3" type="xs:string" use="optional"/>
+                      <xs:attribute name="data_pred_indices" type="xs:string" use="optional"/>
+                      <xs:attribute name="data_format" type="xs:string" use="optional"/>
+                      <xs:attribute name="data_spcformat" type="xs:string" use="optional"/>
+                      <xs:attribute name="data_nobs" type="xs:string" use="optional"/>
+                      <xs:attribute name="data_nind" type="xs:string" use="optional"/>
+                      <xs:attribute name="data_mdv100" type="xs:string" use="optional"/>
+                      <xs:attribute name="msfi_rescaled" type="xs:string" use="optional"/>
+                      <xs:attribute name="nthetat" type="xs:string" use="optional"/>
+                      <xs:attribute name="theta_bound_test_omitted" type="xs:string" use="optional"/>
+                      <xs:attribute name="omega_diagdim" type="xs:string" use="optional"/>
+                      <xs:attribute name="sigma_diagdim" type="xs:string" use="optional"/>
+                      <xs:attribute name="omega_bound_test_omitted" type="xs:string" use="optional"/>
+                      <xs:attribute name="sigma_bound_test_omitted" type="xs:string" use="optional"/>
+                      <xs:attribute name="omega_blockdim" type="xs:string" use="optional"/>
+                      <xs:attribute name="sigma_blockdim" type="xs:string" use="optional"/>
+                      <xs:attribute name="nfn_initial" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_omitted" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_obj_evaluated" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_rewind" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_clockseed" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_supreset" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_with_initial_estimate" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_with_final_estimate" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_with_prior" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_ranmethod" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_newran" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_etader_order_max" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_source_eps" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_ttdf" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed1_01" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed2_01" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_dist_01" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed1_02" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed2_02" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_dist_02" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed1_03" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed2_03" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_dist_03" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed1_04" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed2_04" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_dist_04" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed1_05" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed2_05" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_dist_05" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed1_06" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed2_06" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_dist_06" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed1_07" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed2_07" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_dist_07" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed1_08" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed2_08" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_dist_08" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed1_09" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed2_09" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_dist_09" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed1_10" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed2_10" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_dist_10" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_subprob" type="xs:string" use="optional"/>
+                      <xs:attribute name="nonpar_omitted" type="xs:string" use="optional"/>
+                      <xs:attribute name="nonpar_estim" type="xs:string" use="optional"/>
+                      <xs:attribute name="nonpar_density_recompute" type="xs:string" use="optional"/>
+                      <xs:attribute name="nonpar_marginal_cum" type="xs:string" use="optional"/>
+                      <xs:attribute name="nonpar_pop_etas" type="xs:string" use="optional"/>
+                      <xs:attribute name="nonpar_msfoutput" type="xs:string" use="optional"/>
+                      <xs:attribute name="nonpar_bootstrap" type="xs:string" use="optional"/>
+                      <xs:attribute name="nonpar_stratcol" type="xs:string" use="optional"/>
+                      <xs:attribute name="nonpar_stratfcol" type="xs:string" use="optional"/>
+                      <xs:attribute name="nonpar_support_nodes" type="xs:string" use="optional"/>
+                      <xs:attribute name="nonpar_expand" type="xs:string" use="optional"/>
+                      <xs:attribute name="nonpar_nsuppe" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_omitted" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_matrix" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_rmatrix_print" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_smatrix_print" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_eigen_print" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_special" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_compressed" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_slow_gradient" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_siglocov" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_siglcov" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_tol" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_atol" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_nofcov" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_resume" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_precond" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_preconds" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_thbnd" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_sirthbnd" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_pretype" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_pfcond" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_fposdef" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_posdef" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_sirsample" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_sirniter" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_sircenter" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_capcorr" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_sirminwt" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_sirmaxwt" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_iaccept" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_iacceptl" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_df" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_file" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_format" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_print" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_knuthsumoff" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_cholroff" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_seed" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_clockseed" type="xs:string" use="optional"/>
+                      <xs:attribute name="cov_ranmethod" type="xs:string" use="optional"/>
+                      <xs:attribute name="tab_omitted" type="xs:string" use="optional"/>
+                      <xs:attribute name="tab_number" type="xs:string" use="optional"/>
+                      <xs:attribute name="tab_seed" type="xs:string" use="optional"/>
+                      <xs:attribute name="tab_clockseed" type="xs:string" use="optional"/>
+                      <xs:attribute name="tab_npdtype" type="xs:string" use="optional"/>
+                      <xs:attribute name="tab_interptype" type="xs:string" use="optional"/>
+                      <xs:attribute name="tab_ranmethod" type="xs:string" use="optional"/>
+                      <xs:attribute name="tab_esample" type="xs:string" use="optional"/>
+                      <xs:attribute name="tab_wres" type="xs:string" use="optional"/>
+                      <xs:attribute name="tab_fixedetas_01" type="xs:string" use="optional"/>
+                      <xs:attribute name="tab_fixedetas_02" type="xs:string" use="optional"/>
+                      <xs:attribute name="tab_fixedetas_03" type="xs:string" use="optional"/>
+                      <xs:attribute name="tab_fixedetas_04" type="xs:string" use="optional"/>
+                      <xs:attribute name="tab_fixedetas_05" type="xs:string" use="optional"/>
+                      <xs:attribute name="tab_fixedetas_06" type="xs:string" use="optional"/>
+                      <xs:attribute name="tab_fixedetas_07" type="xs:string" use="optional"/>
+                      <xs:attribute name="tab_fixedetas_08" type="xs:string" use="optional"/>
+                      <xs:attribute name="tab_fixedetas_09" type="xs:string" use="optional"/>
+                      <xs:attribute name="tab_fixedetas_10" type="xs:string" use="optional"/>
+                      <xs:attribute name="scatter_omitted" type="xs:string" use="optional"/>
+                      <xs:attribute name="scatter_number" type="xs:string" use="optional"/>
+                      <xs:attribute name="pred_advan" type="xs:string" use="optional"/>
+                      <xs:attribute name="pred_evid" type="xs:string" use="optional"/>
+                      <xs:attribute name="pred_time" type="xs:string" use="optional"/>
+                      <xs:attribute name="pred_amt" type="xs:string" use="optional"/>
+                      <xs:attribute name="pred_rate" type="xs:string" use="optional"/>
+                      <xs:attribute name="pred_ss" type="xs:string" use="optional"/>
+                      <xs:attribute name="pred_ii" type="xs:string" use="optional"/>
+                      <xs:attribute name="pred_addl" type="xs:string" use="optional"/>
+                      <xs:attribute name="pred_cmt" type="xs:string" use="optional"/>
+                      <xs:attribute name="pred_pcmt" type="xs:string" use="optional"/>
+                      <xs:attribute name="pred_call" type="xs:string" use="optional"/>
+                      <xs:attribute name="pred_cont" type="xs:string" use="optional"/>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="theta_lb" minOccurs="0" maxOccurs="1" type="nm:vector"/>
+                  <xs:element name="theta_in" minOccurs="0" maxOccurs="1" type="nm:vector"/>
+                  <xs:element name="theta_ub" minOccurs="0" maxOccurs="1" type="nm:vector"/>
+                  <xs:element name="chain_record" minOccurs="0" maxOccurs="unbounded">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="chain_record_information" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                        <xs:element name="chain_record_options" minOccurs="0" maxOccurs="1">
+                          <xs:complexType>
+                            <xs:attribute name="notitle" type="xs:string" use="optional"/>
+                            <xs:attribute name="nolabel" type="xs:string" use="optional"/>
+                            <xs:attribute name="format" type="xs:string" use="optional"/>
+                            <xs:attribute name="order" type="xs:string" use="optional"/>
+                            <xs:attribute name="ctype" type="xs:string" use="optional"/>
+                            <xs:attribute name="file" type="xs:string" use="optional"/>
+                            <xs:attribute name="dfs" type="xs:string" use="optional"/>
+                            <xs:attribute name="select" type="xs:string" use="optional"/>
+                            <xs:attribute name="niter" type="xs:string" use="optional"/>
+                            <xs:attribute name="nsample" type="xs:string" use="optional"/>
+                            <xs:attribute name="seed" type="xs:string" use="optional"/>
+                            <xs:attribute name="clockseed" type="xs:string" use="optional"/>
+                            <xs:attribute name="isample" type="xs:string" use="optional"/>
+                            <xs:attribute name="isampend" type="xs:string" use="optional"/>
+                            <xs:attribute name="ranmethod" type="xs:string" use="optional"/>
+                            <xs:attribute name="iaccept" type="xs:string" use="optional"/>
+                            <xs:attribute name="df" type="xs:string" use="optional"/>
+                          </xs:complexType>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="parallel_chain_record" minOccurs="0" maxOccurs="1">
+                    <xs:complexType>
+                      <xs:attribute name="parafile" type="xs:string" use="required"/>
+                      <xs:attribute name="protocol" type="xs:string" use="required"/>
+                      <xs:attribute name="nodes" type="xs:integer" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="parallel_sim" minOccurs="0" maxOccurs="1">
+                    <xs:complexType>
+                      <xs:attribute name="parafile" type="xs:string" use="required"/>
+                      <xs:attribute name="protocol" type="xs:string" use="required"/>
+                      <xs:attribute name="nodes" type="xs:integer" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="simulation_information" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                  <xs:element name="sim_info" minOccurs="0" maxOccurs="1">
+                    <xs:complexType>
+                      <xs:attribute name="superproblem1" type="xs:string" use="optional"/>
+                      <xs:attribute name="iteration1" type="xs:string" use="optional"/>
+                      <xs:attribute name="superproblem2" type="xs:string" use="optional"/>
+                      <xs:attribute name="iteration2" type="xs:string" use="optional"/>
+                      <xs:attribute name="problem" type="xs:string" use="optional"/>
+                      <xs:attribute name="subproblem" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_bootstrap" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_bootstrap_replace" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_stratcol" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_stratfcol" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed1_01" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed2_01" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed1_02" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed2_02" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed1_03" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed2_03" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed1_04" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed2_04" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed1_05" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed2_05" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed1_06" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed2_06" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed1_07" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed2_07" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed1_08" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed2_08" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed1_09" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed2_09" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed1_10" type="xs:string" use="optional"/>
+                      <xs:attribute name="sim_seed2_10" type="xs:string" use="optional"/>
+                      </xs:complexType>
+                  </xs:element>
+                  <xs:element name="sim_elapsed_time" type="xs:double" minOccurs="0" maxOccurs="1" />
+                  <xs:element name="estimation" minOccurs="0" maxOccurs="unbounded">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="parallel_chain_est" minOccurs="0" maxOccurs="1">
+                          <xs:complexType>
+                            <xs:attribute name="parafile" type="xs:string" use="required"/>
+                            <xs:attribute name="protocol" type="xs:string" use="required"/>
+                            <xs:attribute name="nodes" type="xs:integer" use="required"/>
+                          </xs:complexType>
+                        </xs:element>
+                        <xs:element name="parallel_est" minOccurs="0" maxOccurs="1">
+                          <xs:complexType>
+                            <xs:attribute name="parafile" type="xs:string" use="required"/>
+                            <xs:attribute name="protocol" type="xs:string" use="required"/>
+                            <xs:attribute name="nodes" type="xs:integer" use="required"/>
+                          </xs:complexType>
+                        </xs:element>
+                        <xs:element name="table_series" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="estimation_method" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="estimation_title" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="estimation_information" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="estimation_options" minOccurs="0" maxOccurs="1">
+                          <xs:complexType>
+                            <xs:attribute name="estim_omitted" type="xs:string" use="optional"/>
+                            <xs:attribute name="evalshrink" type="xs:string" use="optional"/>
+                            <xs:attribute name="analysis_type" type="xs:string" use="optional"/>
+                            <xs:attribute name="posthoc" type="xs:string" use="optional"/>
+                            <xs:attribute name="fo_model_app" type="xs:string" use="optional"/>
+                            <xs:attribute name="bootdata" type="xs:string" use="optional"/>
+                            <xs:attribute name="saddle_reset" type="xs:string" use="optional"/>
+                            <xs:attribute name="saddle_hess" type="xs:string" use="optional"/>
+                            <xs:attribute name="slow_gradient" type="xs:string" use="optional"/>
+                            <xs:attribute name="cond_estim" type="xs:string" use="optional"/>
+                            <xs:attribute name="etas_fixed_to_zero" type="xs:string" use="optional"/>
+                            <xs:attribute name="epseta_interaction" type="xs:string" use="optional"/>
+                            <xs:attribute name="centered_eta" type="xs:string" use="optional"/>
+                            <xs:attribute name="laplace" type="xs:string" use="optional"/>
+                            <xs:attribute name="numerical_2nd_der" type="xs:string" use="optional"/>
+                            <xs:attribute name="stieltjes" type="xs:string" use="optional"/>
+                            <xs:attribute name="nfractiles" type="xs:string" use="optional"/>
+                            <xs:attribute name="ndirections" type="xs:string" use="optional"/>
+                            <xs:attribute name="leftpoint" type="xs:string" use="optional"/>
+                            <xs:attribute name="rightpoint" type="xs:string" use="optional"/>
+                            <xs:attribute name="predflag" type="xs:string" use="optional"/>
+                            <xs:attribute name="maxfn" type="xs:string" use="optional"/>
+                            <xs:attribute name="nsig" type="xs:string" use="optional"/>
+                            <xs:attribute name="msfo" type="xs:string" use="optional"/>
+                            <xs:attribute name="conv_repeat" type="xs:string" use="optional"/>
+                            <xs:attribute name="conv_repeat1" type="xs:string" use="optional"/>
+                            <xs:attribute name="conv_repeat2" type="xs:string" use="optional"/>
+                            <xs:attribute name="abort" type="xs:string" use="optional"/>
+                            <xs:attribute name="objsort" type="xs:string" use="optional"/>
+                            <xs:attribute name="numder" type="xs:string" use="optional"/>
+                            <xs:attribute name="optmap" type="xs:string" use="optional"/>
+                            <xs:attribute name="etader" type="xs:string" use="optional"/>
+                            <xs:attribute name="mceta" type="xs:string" use="optional"/>
+                            <xs:attribute name="siglo" type="xs:string" use="optional"/>
+                            <xs:attribute name="sigl" type="xs:string" use="optional"/>
+                            <xs:attribute name="notitle" type="xs:string" use="optional"/>
+                            <xs:attribute name="nolabel" type="xs:string" use="optional"/>
+                            <xs:attribute name="noprior" type="xs:string" use="optional"/>
+                            <xs:attribute name="nocov" type="xs:string" use="optional"/>
+                            <xs:attribute name="dercont" type="xs:string" use="optional"/>
+                            <xs:attribute name="atol" type="xs:string" use="optional"/>
+                            <xs:attribute name="fnleta" type="xs:string" use="optional"/>
+                            <xs:attribute name="etastype" type="xs:string" use="optional"/>
+                            <xs:attribute name="noninfeta" type="xs:string" use="optional"/>
+                            <xs:attribute name="format" type="xs:string" use="optional"/>
+                            <xs:attribute name="order" type="xs:string" use="optional"/>
+                            <xs:attribute name="estimation_method" type="xs:string" use="optional"/>
+                            <xs:attribute name="nuts_type" type="xs:string" use="optional"/>
+                            <xs:attribute name="bionly" type="xs:string" use="optional"/>
+                            <xs:attribute name="mum" type="xs:string" use="optional"/>
+                            <xs:attribute name="grd" type="xs:string" use="optional"/>
+                            <xs:attribute name="auto" type="xs:string" use="optional"/>
+                            <xs:attribute name="ctype" type="xs:string" use="optional"/>
+                            <xs:attribute name="thin" type="xs:string" use="optional"/>
+                            <xs:attribute name="cinterval" type="xs:string" use="optional"/>
+                            <xs:attribute name="citer" type="xs:string" use="optional"/>
+                            <xs:attribute name="calpha" type="xs:string" use="optional"/>
+                            <xs:attribute name="nburn" type="xs:string" use="optional"/>
+                            <xs:attribute name="mapiters" type="xs:string" use="optional"/>
+                            <xs:attribute name="select" type="xs:string" use="optional"/>
+                            <xs:attribute name="dfs" type="xs:string" use="optional"/>
+                            <xs:attribute name="file" type="xs:string" use="optional"/>
+                            <xs:attribute name="niter" type="xs:string" use="optional"/>
+                            <xs:attribute name="nsample" type="xs:string" use="optional"/>
+                            <xs:attribute name="constrain" type="xs:string" use="optional"/>
+                            <xs:attribute name="anneal" type="xs:string" use="optional"/>
+                            <xs:attribute name="level" type="xs:string" use="optional"/>
+                            <xs:attribute name="seed" type="xs:string" use="optional"/>
+                            <xs:attribute name="clockseed" type="xs:string" use="optional"/>
+                            <xs:attribute name="isample" type="xs:string" use="optional"/>
+                            <xs:attribute name="isampend" type="xs:string" use="optional"/>
+                            <xs:attribute name="ranmethod" type="xs:string" use="optional"/>
+                            <xs:attribute name="eonly" type="xs:string" use="optional"/>
+                            <xs:attribute name="iscale_min" type="xs:string" use="optional"/>
+                            <xs:attribute name="iscale_max" type="xs:string" use="optional"/>
+                            <xs:attribute name="iaccept" type="xs:string" use="optional"/>
+                            <xs:attribute name="iacceptl" type="xs:string" use="optional"/>
+                            <xs:attribute name="df" type="xs:string" use="optional"/>
+                            <xs:attribute name="mapiter" type="xs:string" use="optional"/>
+                            <xs:attribute name="mapinter" type="xs:string" use="optional"/>
+                            <xs:attribute name="mapcov" type="xs:string" use="optional"/>
+                            <xs:attribute name="grdq" type="xs:string" use="optional"/>
+                            <xs:attribute name="massreset" type="xs:string" use="optional"/>
+                            <xs:attribute name="nuts_mass" type="xs:string" use="optional"/>
+                            <xs:attribute name="kappa" type="xs:string" use="optional"/>
+                            <xs:attribute name="ikappa" type="xs:string" use="optional"/>
+                            <xs:attribute name="nuts_gamma" type="xs:string" use="optional"/>
+                            <xs:attribute name="igamma" type="xs:string" use="optional"/>
+                            <xs:attribute name="nuts_delta" type="xs:string" use="optional"/>
+                            <xs:attribute name="idelta" type="xs:string" use="optional"/>
+                            <xs:attribute name="madapt" type="xs:string" use="optional"/>
+                            <xs:attribute name="imadapt" type="xs:string" use="optional"/>
+                            <xs:attribute name="ttdf" type="xs:string" use="optional"/>
+                            <xs:attribute name="tpu" type="xs:string" use="optional"/>
+                            <xs:attribute name="olkjdf" type="xs:string" use="optional"/>
+                            <xs:attribute name="ovarf" type="xs:string" use="optional"/>
+                            <xs:attribute name="slkjdf" type="xs:string" use="optional"/>
+                            <xs:attribute name="svarf" type="xs:string" use="optional"/>
+                            <xs:attribute name="nuts_transform" type="xs:string" use="optional"/>
+                            <xs:attribute name="inuts_transform" type="xs:string" use="optional"/>
+                            <xs:attribute name="nuts_eparam" type="xs:string" use="optional"/>
+                            <xs:attribute name="nuts_oparam" type="xs:string" use="optional"/>
+                            <xs:attribute name="nuts_sparam" type="xs:string" use="optional"/>
+                            <xs:attribute name="nuts_reg" type="xs:string" use="optional"/>
+                            <xs:attribute name="nuts_cholbnd" type="xs:string" use="optional"/>
+                            <xs:attribute name="nuts_init" type="xs:string" use="optional"/>
+                            <xs:attribute name="nuts_test" type="xs:string" use="optional"/>
+                            <xs:attribute name="nuts_maxdepth" type="xs:string" use="optional"/>
+                            <xs:attribute name="nuts_term" type="xs:string" use="optional"/>
+                            <xs:attribute name="knuthsumoff" type="xs:string" use="optional"/>
+                            <xs:attribute name="wishtype" type="xs:string" use="optional"/>
+                            <xs:attribute name="levwt" type="xs:string" use="optional"/>
+                            <xs:attribute name="levcenter" type="xs:string" use="optional"/>
+                            <xs:attribute name="levobjtype" type="xs:string" use="optional"/>
+                            <xs:attribute name="nuts_base" type="xs:string" use="optional"/>
+                            <xs:attribute name="nuts_stepinter" type="xs:string" use="optional"/>
+                            <xs:attribute name="nuts_stepiter" type="xs:string" use="optional"/>
+                            <xs:attribute name="lntwopi" type="xs:string" use="optional"/>
+                            <xs:attribute name="olntwopi" type="xs:string" use="optional"/>
+                            <xs:attribute name="priorc" type="xs:string" use="optional"/>
+                            <xs:attribute name="stdobj" type="xs:string" use="optional"/>
+                            <xs:attribute name="isample_m1" type="xs:string" use="optional"/>
+                            <xs:attribute name="isample_m1a" type="xs:string" use="optional"/>
+                            <xs:attribute name="isample_m1b" type="xs:string" use="optional"/>
+                            <xs:attribute name="isample_m2" type="xs:string" use="optional"/>
+                            <xs:attribute name="isample_m3" type="xs:string" use="optional"/>
+                            <xs:attribute name="pscale_min" type="xs:string" use="optional"/>
+                            <xs:attribute name="pscale_max" type="xs:string" use="optional"/>
+                            <xs:attribute name="paccept" type="xs:string" use="optional"/>
+                            <xs:attribute name="psample_m1" type="xs:string" use="optional"/>
+                            <xs:attribute name="psample_m2" type="xs:string" use="optional"/>
+                            <xs:attribute name="psample_m3" type="xs:string" use="optional"/>
+                            <xs:attribute name="oaccept" type="xs:string" use="optional"/>
+                            <xs:attribute name="osample_m1" type="xs:string" use="optional"/>
+                            <xs:attribute name="osample_m2" type="xs:string" use="optional"/>
+                            <xs:attribute name="osample_m3" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_groupsize" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_ofvtype" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_ofvdimscaled" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_eopt" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_datasim" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_fimtype" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_varcross" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_mode_assess" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_estimation" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_nmincol" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_nmaxcol" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_stratcol" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_stratfcol" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_seed" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_clockseed" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselcol_01" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselstratcol_01" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselmincol_01" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselmaxcol_01" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselcol_02" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselstratcol_02" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselmincol_02" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselmaxcol_02" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselcol_03" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselstratcol_03" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselmincol_03" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselmaxcol_03" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselcol_04" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselstratcol_04" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselmincol_04" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselmaxcol_04" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselcol_05" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselstratcol_05" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselmincol_05" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselmaxcol_05" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselcol_06" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselstratcol_06" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselmincol_06" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselmaxcol_06" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselcol_07" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselstratcol_07" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselmincol_07" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselmaxcol_07" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselcol_08" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselstratcol_08" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselmincol_08" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselmaxcol_08" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselcol_09" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselstratcol_09" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselmincol_09" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselmaxcol_09" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselcol_10" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselstratcol_10" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselmincol_10" type="xs:string" use="optional"/>
+                            <xs:attribute name="optd_deselmaxcol_10" type="xs:string" use="optional"/>
+                          </xs:complexType>
+                        </xs:element>
+
+                        <xs:element name="monitor" minOccurs="0" maxOccurs="1">
+                          <xs:complexType>
+                            <xs:sequence>
+                              <xs:element name="obj" minOccurs="0" maxOccurs="unbounded">
+                                <xs:complexType>
+                                  <xs:simpleContent>
+                                    <xs:extension base="xs:double">
+                                    <xs:attribute name="iteration" type="xs:integer" use="required"/>
+                                    <xs:attribute name="sample" type="xs:double" use="optional"/>
+                                    <xs:attribute name="effective" type="xs:double" use="optional"/>
+                                    <xs:attribute name="fitness" type="xs:double" use="optional"/>
+                                    </xs:extension>
+                                  </xs:simpleContent>
+                                </xs:complexType>
+                              </xs:element>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                        <xs:element name="termination_status" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="termination_nfuncevals" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="termination_sigdigits" type="xs:double" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="termination_information" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="termination_txtmsg" minOccurs="0" maxOccurs="1" type="nm:vector"/>
+                        <xs:element name="etabar" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="etabarse" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="etabarn" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="etabarpval" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="etashrinksd" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="etashrinkvr" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="ebvshrinksd" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="ebvshrinkvr" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="relativeinf" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="epsshrinksd" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="epsshrinkvr" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="estimation_burnin_time" type="xs:double" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="estimation_elapsed_time" type="xs:double" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="optd_elapsed_time" type="xs:double" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="parallel_cov" minOccurs="0" maxOccurs="1">
+                          <xs:complexType>
+                            <xs:attribute name="parafile" type="xs:string" use="required"/>
+                            <xs:attribute name="protocol" type="xs:string" use="required"/>
+                            <xs:attribute name="nodes" type="xs:integer" use="required"/>
+                          </xs:complexType>
+                        </xs:element>
+                        <xs:element name="covariance_information" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="covariance_status" minOccurs="0" maxOccurs="1">
+                          <xs:complexType>
+                            <xs:attribute name="error" type="xs:integer" use="required"/>
+                            <xs:attribute name="numnegeigenvalues" type="xs:integer" use="required"/>
+                            <xs:attribute name="mineigenvalue" type="xs:double" use="required"/>
+                            <xs:attribute name="maxeigenvalue" type="xs:double" use="required"/>
+                            <xs:attribute name="rms" type="xs:double" use="required"/>
+                          </xs:complexType>
+                        </xs:element>
+                        <xs:element name="covariance_elapsed_time" type="xs:double" minOccurs="0" maxOccurs="1" />
+                        <xs:element name="parallel_fnleta" minOccurs="0" maxOccurs="1">
+                          <xs:complexType>
+                            <xs:attribute name="parafile" type="xs:string" use="required"/>
+                            <xs:attribute name="protocol" type="xs:string" use="required"/>
+                            <xs:attribute name="nodes" type="xs:integer" use="required"/>
+                          </xs:complexType>
+                        </xs:element>
+                        <xs:element name="parallel_nonparo" minOccurs="0" maxOccurs="1">
+                          <xs:complexType>
+                            <xs:attribute name="parafile" type="xs:string" use="required"/>
+                            <xs:attribute name="protocol" type="xs:string" use="required"/>
+                            <xs:attribute name="nodes" type="xs:integer" use="required"/>
+                          </xs:complexType>
+                        </xs:element>
+                        <xs:element name="parallel_nonpar" minOccurs="0" maxOccurs="1">
+                          <xs:complexType>
+                            <xs:attribute name="parafile" type="xs:string" use="required"/>
+                            <xs:attribute name="protocol" type="xs:string" use="required"/>
+                            <xs:attribute name="nodes" type="xs:integer" use="required"/>
+                          </xs:complexType>
+                        </xs:element>
+                        <xs:element name="nonpar_elapsed_time" type="xs:double" minOccurs="0" maxOccurs="1" />
+                        <xs:element name="parallel_wres" minOccurs="0" maxOccurs="1">
+                          <xs:complexType>
+                            <xs:attribute name="parafile" type="xs:string" use="required"/>
+                            <xs:attribute name="protocol" type="xs:string" use="required"/>
+                            <xs:attribute name="nodes" type="xs:integer" use="required"/>
+                          </xs:complexType>
+                        </xs:element>
+                        <xs:element name="final_objective_function_text" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="final_objective_function" type="xs:double" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="final_objective_function_std"  minOccurs="0" maxOccurs="1" type="xs:double"/>
+                        <xs:element name="cnv_objective_function" type="xs:double" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="cnv_objective_function_std"  minOccurs="0" maxOccurs="1" type="xs:double"/>
+                        <xs:element name="theta" minOccurs="0" maxOccurs="1" type="nm:vector"/>
+                        <xs:element name="omega" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="sigma" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="omegac" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="sigmac" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="thetase" minOccurs="0" maxOccurs="1" type="nm:vector"/>
+                        <xs:element name="omegase" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="sigmase" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="omegacse" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="sigmacse" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="covariance" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="correlation" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="invcovariance" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="rmatrix" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="smatrix" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="eigenvalues" minOccurs="0" maxOccurs="1" type="nm:vector"/>
+                        <xs:element name="nonpar_elapsed_timeb" type="xs:double" minOccurs="0" maxOccurs="1" />
+                        <xs:element name="np_objective_function" type="xs:double" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="thetanp" minOccurs="0" maxOccurs="1" type="nm:vector"/>
+                        <xs:element name="exnpeta" minOccurs="0" maxOccurs="1" type="nm:vector"/>
+                        <xs:element name="covnpeta" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="omeganp" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="covnpetac" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="omeganpc" minOccurs="0" maxOccurs="1" type="nm:table"/>                       
+                      </xs:sequence>
+                      <xs:attribute name="number" type="xs:integer" use="required"/>
+                      <xs:attribute name="type" type="xs:integer" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="parallel_fnleta" minOccurs="0" maxOccurs="1">
+                    <xs:complexType>
+                      <xs:attribute name="parafile" type="xs:string" use="required"/>
+                      <xs:attribute name="protocol" type="xs:string" use="required"/>
+                      <xs:attribute name="nodes" type="xs:integer" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="parallel_wres" minOccurs="0" maxOccurs="1">
+                    <xs:complexType>
+                      <xs:attribute name="parafile" type="xs:string" use="required"/>
+                      <xs:attribute name="protocol" type="xs:string" use="required"/>
+                      <xs:attribute name="nodes" type="xs:integer" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="table" minOccurs="0" maxOccurs="unbounded" type="nm:table"/>
+                  <xs:element name="scatter" minOccurs="0" maxOccurs="unbounded">
+                    <xs:complexType>
+                      <xs:simpleContent>
+                        <xs:extension base="xs:string">
+                          <xs:attribute name="number" type="xs:integer" use="required"/>
+                          <xs:attribute name="ord" type="xs:string" use="required"/>
+                          <xs:attribute name="abs" type="xs:string" use="required"/>
+                        </xs:extension>
+                      </xs:simpleContent>
+                    </xs:complexType>                  
+                  </xs:element>
+                  <xs:element name="post_process_times" minOccurs="0" maxOccurs="unbounded">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="post_elapsed_time" type="xs:double" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="finaloutput_elapsed_time" type="xs:double" minOccurs="0" maxOccurs="1" />
+                      </xs:sequence>
+                    </xs:complexType>                  
+                  </xs:element>
+
+                  <xs:element name="parallel_sir" minOccurs="0" maxOccurs="1">
+                    <xs:complexType>
+                      <xs:attribute name="parafile" type="xs:string" use="required"/>
+                      <xs:attribute name="protocol" type="xs:string" use="required"/>
+                      <xs:attribute name="nodes" type="xs:integer" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+
+                  <xs:element name="sir_estimation" minOccurs="0" maxOccurs="unbounded">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="table_series" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="estimation_method" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="estimation_title" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="monitor" minOccurs="0" maxOccurs="1">
+                          <xs:complexType>
+                            <xs:sequence>
+                              <xs:element name="obj" minOccurs="0" maxOccurs="unbounded">
+                                <xs:complexType>
+                                  <xs:simpleContent>
+                                    <xs:extension base="xs:double">
+                                    <xs:attribute name="iteration" type="xs:integer" use="required"/>
+                                    <xs:attribute name="sample" type="xs:double" use="optional"/>
+                                    <xs:attribute name="effective" type="xs:double" use="optional"/>
+                                    <xs:attribute name="fitness" type="xs:double" use="optional"/>
+                                    </xs:extension>
+                                  </xs:simpleContent>
+                                </xs:complexType>
+                              </xs:element>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                        <xs:element name="termination_status" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="termination_information" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="estimation_elapsed_time" type="xs:double" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="final_objective_function_text" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="final_objective_function" type="xs:double" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="final_objective_function_std"  minOccurs="0" maxOccurs="1" type="xs:double"/>
+                        <xs:element name="cnv_objective_function" type="xs:double" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="cnv_objective_function_std"  minOccurs="0" maxOccurs="1" type="xs:double"/>
+                        <xs:element name="theta" minOccurs="0" maxOccurs="1" type="nm:vector"/>
+                        <xs:element name="omega" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="sigma" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="omegac" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="sigmac" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="thetase" minOccurs="0" maxOccurs="1" type="nm:vector"/>
+                        <xs:element name="omegase" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="sigmase" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="omegacse" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="sigmacse" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="covariance" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="correlation" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="invcovariance" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="rmatrix" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="smatrix" minOccurs="0" maxOccurs="1" type="nm:table"/>
+                        <xs:element name="eigenvalues" minOccurs="0" maxOccurs="1" type="nm:vector"/>
+                      </xs:sequence>
+                      <xs:attribute name="number" type="xs:integer" use="required"/>
+                      <xs:attribute name="type" type="xs:integer" use="required"/>
+                    </xs:complexType>
+                  </xs:element>
+
+                </xs:sequence>
+                <xs:attribute name="number" type="xs:integer" use="required"/>
+                <xs:attribute name="subproblem" type="xs:integer" use="required"/>
+                <xs:attribute name="superproblem1" type="xs:integer" use="required"/>
+                <xs:attribute name="iteration1" type="xs:integer" use="required"/>
+                <xs:attribute name="superproblem2" type="xs:integer" use="required"/>
+                <xs:attribute name="iteration2" type="xs:integer" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="version" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="stop_datetime" type="xs:dateTime"/>
+      <xs:element name="total_cputime" type="xs:double"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:element>
+
+<xs:complexType name="table">
+  <xs:sequence>
+    <xs:element name="title" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    <xs:element name="row" minOccurs="0" maxOccurs="unbounded">
+      <xs:complexType>
+        <xs:sequence>
+          <xs:element name="col" minOccurs="0" maxOccurs="unbounded">
+            <xs:complexType>
+              <xs:simpleContent>
+                <xs:extension base="xs:double">
+                  <xs:attribute name="cname" type="xs:string" use="optional"/>
+                </xs:extension>
+              </xs:simpleContent>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+        <xs:attribute name="rname" use="optional" type="xs:string"/>
+      </xs:complexType>
+    </xs:element>
+  </xs:sequence>
+  <xs:attribute name="number" use="optional" type="xs:integer"/>
+</xs:complexType>
+
+<xs:complexType name="vector">
+  <xs:sequence>
+    <xs:element name="title" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    <xs:element name="val" minOccurs="0" maxOccurs="unbounded">
+      <xs:complexType>
+        <xs:simpleContent>
+          <xs:extension base="xs:double">
+            <xs:attribute name="name" type="xs:string" use="optional"/>
+          </xs:extension>
+        </xs:simpleContent>
+      </xs:complexType>
+    </xs:element>
+  </xs:sequence>
+  <xs:attribute name="number" use="optional" type="xs:integer"/>
+</xs:complexType>
+
+
+</xs:schema>

--- a/src/Census.App/App.axaml
+++ b/src/Census.App/App.axaml
@@ -3,11 +3,29 @@
              x:Class="Census.App.App"
              RequestedThemeVariant="Light">
 
+  <Application.Resources>
+    <!-- Grid contents/headers font size. User-configurable; updated live from Preferences. -->
+    <x:Double x:Key="GridFontSize">11</x:Double>
+    <!-- Standardize the Fluent tab-header font to match the rest of the UI. -->
+    <x:Double x:Key="TabItemHeaderFontSize">12</x:Double>
+  </Application.Resources>
+
   <Application.Styles>
     <FluentTheme />
     <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml"/>
     <Style Selector="Window">
       <Setter Property="FontFamily" Value="Segoe UI Variable Text,Segoe UI,sans-serif" />
+      <Setter Property="FontSize" Value="12" />
+    </Style>
+    <!-- Grid contents and column headers use the user-configurable grid font size. -->
+    <Style Selector="DataGridCell">
+      <Setter Property="FontSize" Value="{DynamicResource GridFontSize}" />
+    </Style>
+    <Style Selector="DataGridColumnHeader">
+      <Setter Property="FontSize" Value="{DynamicResource GridFontSize}" />
+    </Style>
+    <!-- Standardize tab-header font size with everything else. -->
+    <Style Selector="TabItem">
       <Setter Property="FontSize" Value="12" />
     </Style>
   </Application.Styles>

--- a/src/Census.App/App.axaml
+++ b/src/Census.App/App.axaml
@@ -5,6 +5,7 @@
 
   <Application.Styles>
     <FluentTheme />
+    <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml"/>
   </Application.Styles>
 
 </Application>

--- a/src/Census.App/App.axaml
+++ b/src/Census.App/App.axaml
@@ -1,11 +1,15 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="Census.App.App"
-             RequestedThemeVariant="Default">
+             RequestedThemeVariant="Light">
 
   <Application.Styles>
     <FluentTheme />
     <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml"/>
+    <Style Selector="Window">
+      <Setter Property="FontFamily" Value="Segoe UI Variable Text,Segoe UI,sans-serif" />
+      <Setter Property="FontSize" Value="12" />
+    </Style>
   </Application.Styles>
 
 </Application>

--- a/src/Census.App/App.axaml.cs
+++ b/src/Census.App/App.axaml.cs
@@ -1,8 +1,10 @@
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+using Census.App.Services;
 using Census.App.ViewModels;
 using Census.App.Views;
+using Census.Storage;
 
 namespace Census.App;
 
@@ -16,7 +18,10 @@ public partial class App : Application
         {
             desktop.MainWindow = new MainWindow
             {
-                DataContext = new MainWindowViewModel(),
+                DataContext = new MainWindowViewModel(
+                    new SqliteProjectStore(),
+                    new AvaloniaDialogService(),
+                    new JsonSettingsService()),
             };
         }
 

--- a/src/Census.App/App.axaml.cs
+++ b/src/Census.App/App.axaml.cs
@@ -16,12 +16,16 @@ public partial class App : Application
     {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
+            var settings = new JsonSettingsService();
+            // Apply the saved grid font size before the main window resolves the resource.
+            Resources["GridFontSize"] = settings.Load().GridFontSize;
+
             desktop.MainWindow = new MainWindow
             {
                 DataContext = new MainWindowViewModel(
                     new SqliteProjectStore(),
                     new AvaloniaDialogService(),
-                    new JsonSettingsService()),
+                    settings),
             };
         }
 

--- a/src/Census.App/Census.App.csproj
+++ b/src/Census.App/Census.App.csproj
@@ -21,7 +21,6 @@
     <!-- Run tree uses the built-in free TreeView. Avalonia.Controls.TreeDataGrid is a
          commercial (Avalonia Accelerate) control and is intentionally not used. -->
     <PackageReference Include="Avalonia.Desktop" />
-    <PackageReference Include="Avalonia.Fonts.Inter" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Include="CommunityToolkit.Mvvm" />
   </ItemGroup>

--- a/src/Census.App/Models/AppSettings.cs
+++ b/src/Census.App/Models/AppSettings.cs
@@ -7,4 +7,7 @@ public sealed class AppSettings
     public string PsnPath { get; set; } = string.Empty;
     public string PerlPath { get; set; } = string.Empty;
     public string RPath { get; set; } = string.Empty;
+
+    /// <summary>Font size for grid contents and headers. User-configurable in Preferences.</summary>
+    public double GridFontSize { get; set; } = 11;
 }

--- a/src/Census.App/Models/AppSettings.cs
+++ b/src/Census.App/Models/AppSettings.cs
@@ -1,0 +1,10 @@
+namespace Census.App.Models;
+
+public sealed class AppSettings
+{
+    public List<string> RecentProjects { get; set; } = [];
+    public string NonmemPath { get; set; } = string.Empty;
+    public string PsnPath { get; set; } = string.Empty;
+    public string PerlPath { get; set; } = string.Empty;
+    public string RPath { get; set; } = string.Empty;
+}

--- a/src/Census.App/Program.cs
+++ b/src/Census.App/Program.cs
@@ -15,6 +15,5 @@ internal static class Program
     public static AppBuilder BuildAvaloniaApp()
         => AppBuilder.Configure<App>()
             .UsePlatformDetect()
-            .WithInterFont()
             .LogToTrace();
 }

--- a/src/Census.App/Services/AvaloniaDialogService.cs
+++ b/src/Census.App/Services/AvaloniaDialogService.cs
@@ -1,0 +1,90 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Platform.Storage;
+
+namespace Census.App.Services;
+
+public sealed class AvaloniaDialogService : IDialogService
+{
+    private static Window MainWindow =>
+        ((IClassicDesktopStyleApplicationLifetime)Application.Current!.ApplicationLifetime!).MainWindow!;
+
+    public async Task<string?> OpenProjectAsync()
+    {
+        var files = await TopLevel.GetTopLevel(MainWindow)!.StorageProvider.OpenFilePickerAsync(
+            new FilePickerOpenOptions
+            {
+                Title = "Open Census Project",
+                AllowMultiple = false,
+                FileTypeFilter = [new FilePickerFileType("Census Project") { Patterns = ["*.cen"] }],
+            });
+        return files.Count > 0 ? files[0].TryGetLocalPath() : null;
+    }
+
+    public async Task<string?> CreateProjectAsync()
+    {
+        var file = await TopLevel.GetTopLevel(MainWindow)!.StorageProvider.SaveFilePickerAsync(
+            new FilePickerSaveOptions
+            {
+                Title = "Create Census Project",
+                SuggestedFileName = "project.cen",
+                FileTypeChoices = [new FilePickerFileType("Census Project") { Patterns = ["*.cen"] }],
+            });
+        return file?.TryGetLocalPath();
+    }
+
+    public async Task<string?> OpenImportFileAsync()
+    {
+        var files = await TopLevel.GetTopLevel(MainWindow)!.StorageProvider.OpenFilePickerAsync(
+            new FilePickerOpenOptions
+            {
+                Title = "Import NONMEM Run",
+                AllowMultiple = false,
+                FileTypeFilter = [
+                    new FilePickerFileType("NONMEM XML Output") { Patterns = ["*.xml"] },
+                    new FilePickerFileType("All Files") { Patterns = ["*"] },
+                ],
+            });
+        return files.Count > 0 ? files[0].TryGetLocalPath() : null;
+    }
+
+    public async Task<string?> OpenImportFolderAsync()
+    {
+        var folders = await TopLevel.GetTopLevel(MainWindow)!.StorageProvider.OpenFolderPickerAsync(
+            new FolderPickerOpenOptions
+            {
+                Title = "Import Folder",
+                AllowMultiple = false,
+            });
+        return folders.Count > 0 ? folders[0].TryGetLocalPath() : null;
+    }
+
+    public async Task<string?> SaveReportAsync(string suggestedName)
+    {
+        var file = await TopLevel.GetTopLevel(MainWindow)!.StorageProvider.SaveFilePickerAsync(
+            new FilePickerSaveOptions
+            {
+                Title = "Export Report",
+                SuggestedFileName = suggestedName,
+                FileTypeChoices = [
+                    new FilePickerFileType("HTML") { Patterns = ["*.html"] },
+                    new FilePickerFileType("CSV") { Patterns = ["*.csv"] },
+                    new FilePickerFileType("LaTeX") { Patterns = ["*.tex"] },
+                ],
+            });
+        return file?.TryGetLocalPath();
+    }
+
+    public async Task<string?> SaveArchiveAsync(string suggestedName)
+    {
+        var file = await TopLevel.GetTopLevel(MainWindow)!.StorageProvider.SaveFilePickerAsync(
+            new FilePickerSaveOptions
+            {
+                Title = "Archive Run",
+                SuggestedFileName = suggestedName,
+                FileTypeChoices = [new FilePickerFileType("ZIP Archive") { Patterns = ["*.zip"] }],
+            });
+        return file?.TryGetLocalPath();
+    }
+}

--- a/src/Census.App/Services/IDialogService.cs
+++ b/src/Census.App/Services/IDialogService.cs
@@ -1,0 +1,11 @@
+namespace Census.App.Services;
+
+public interface IDialogService
+{
+    Task<string?> OpenProjectAsync();
+    Task<string?> CreateProjectAsync();
+    Task<string?> OpenImportFileAsync();
+    Task<string?> OpenImportFolderAsync();
+    Task<string?> SaveReportAsync(string suggestedName);
+    Task<string?> SaveArchiveAsync(string suggestedName);
+}

--- a/src/Census.App/Services/ISettingsService.cs
+++ b/src/Census.App/Services/ISettingsService.cs
@@ -6,6 +6,7 @@ public interface ISettingsService
 {
     AppSettings Load();
     void Save(AppSettings settings);
+    void UpdateSettings(Action<AppSettings> mutate);
     void AddRecentProject(string path);
     IReadOnlyList<string> GetRecentProjects();
 }

--- a/src/Census.App/Services/ISettingsService.cs
+++ b/src/Census.App/Services/ISettingsService.cs
@@ -1,0 +1,11 @@
+using Census.App.Models;
+
+namespace Census.App.Services;
+
+public interface ISettingsService
+{
+    AppSettings Load();
+    void Save(AppSettings settings);
+    void AddRecentProject(string path);
+    IReadOnlyList<string> GetRecentProjects();
+}

--- a/src/Census.App/Services/JsonSettingsService.cs
+++ b/src/Census.App/Services/JsonSettingsService.cs
@@ -1,0 +1,50 @@
+using System.Text.Json;
+using Census.App.Models;
+
+namespace Census.App.Services;
+
+public sealed class JsonSettingsService : ISettingsService
+{
+    private static readonly string SettingsPath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "Census", "settings.json");
+
+    private AppSettings _cache = new();
+
+    public JsonSettingsService() => _cache = Load();
+
+    public AppSettings Load()
+    {
+        try
+        {
+            if (File.Exists(SettingsPath))
+            {
+                var json = File.ReadAllText(SettingsPath);
+                return JsonSerializer.Deserialize<AppSettings>(json) ?? new AppSettings();
+            }
+        }
+        catch { /* ignore corrupt settings */ }
+        return new AppSettings();
+    }
+
+    public void Save(AppSettings settings)
+    {
+        _cache = settings;
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(SettingsPath)!);
+            File.WriteAllText(SettingsPath, JsonSerializer.Serialize(settings, new JsonSerializerOptions { WriteIndented = true }));
+        }
+        catch { /* ignore save failures */ }
+    }
+
+    public void AddRecentProject(string path)
+    {
+        _cache.RecentProjects.Remove(path);
+        _cache.RecentProjects.Insert(0, path);
+        if (_cache.RecentProjects.Count > 10) _cache.RecentProjects.RemoveRange(10, _cache.RecentProjects.Count - 10);
+        Save(_cache);
+    }
+
+    public IReadOnlyList<string> GetRecentProjects() => _cache.RecentProjects.AsReadOnly();
+}

--- a/src/Census.App/Services/JsonSettingsService.cs
+++ b/src/Census.App/Services/JsonSettingsService.cs
@@ -38,6 +38,12 @@ public sealed class JsonSettingsService : ISettingsService
         catch { /* ignore save failures */ }
     }
 
+    public void UpdateSettings(Action<AppSettings> mutate)
+    {
+        mutate(_cache);
+        Save(_cache);
+    }
+
     public void AddRecentProject(string path)
     {
         _cache.RecentProjects.Remove(path);

--- a/src/Census.App/ViewModels/EstimationStepViewModel.cs
+++ b/src/Census.App/ViewModels/EstimationStepViewModel.cs
@@ -1,0 +1,38 @@
+using System.Globalization;
+using Census.Domain;
+
+namespace Census.App.ViewModels;
+
+/// <summary>
+/// One estimation step shown in the bottom-left "Estimation" grid. Selecting a step
+/// drives the parameter tabs (theta/omega/sigma) on the right.
+/// </summary>
+public sealed class EstimationStepViewModel
+{
+    public EstimationStepViewModel(Estimation est)
+    {
+        Step = est.Number;
+        Title = est.Method ?? string.Empty;
+        Status = est.Warnings.Count > 0 ? "Terminated" : "Successful";
+        Ofv = est.Ofv?.ToString("0.000", CultureInfo.InvariantCulture) ?? string.Empty;
+        ConditionNumber = est.ConditionNumber?.ToString("0.###", CultureInfo.InvariantCulture) ?? string.Empty;
+
+        var ps = est.Parameters;
+        Thetas = ps.Where(p => p.Kind == ParameterKind.Theta).Select(p => new ParameterRowViewModel(p)).ToList();
+        Omegas = ps.Where(p => p.Kind == ParameterKind.Omega).Select(p => new ParameterRowViewModel(p)).ToList();
+        Sigmas = ps.Where(p => p.Kind == ParameterKind.Sigma).Select(p => new ParameterRowViewModel(p)).ToList();
+        Warnings = est.Warnings;
+    }
+
+    public int Step { get; }
+    public string Title { get; }
+    public string Status { get; }
+    public string Ofv { get; }
+    public string ConditionNumber { get; }
+    public IReadOnlyList<ParameterRowViewModel> Thetas { get; }
+    public IReadOnlyList<ParameterRowViewModel> Omegas { get; }
+    public IReadOnlyList<ParameterRowViewModel> Sigmas { get; }
+    public IReadOnlyList<string> Warnings { get; }
+
+    public override string ToString() => $"{Step}: {Title}";
+}

--- a/src/Census.App/ViewModels/EstimationStepViewModel.cs
+++ b/src/Census.App/ViewModels/EstimationStepViewModel.cs
@@ -4,16 +4,21 @@ using Census.Domain;
 namespace Census.App.ViewModels;
 
 /// <summary>
-/// One estimation step shown in the bottom-left "Estimation" grid. Selecting a step
-/// drives the parameter tabs (theta/omega/sigma) on the right.
+/// A row in the bottom-left "Estimation" grid. Most rows are estimation steps (selecting
+/// one drives the parameter tabs). The grid also carries run-level timing rows
+/// (start/stop time, total CPU time, post-processing times) appended after the steps.
 /// </summary>
 public sealed class EstimationStepViewModel
 {
+    /// <summary>Estimation-step row.</summary>
     public EstimationStepViewModel(Estimation est)
     {
-        Step = est.Number;
+        IsEstimation = true;
+        Step = est.Number.ToString(CultureInfo.InvariantCulture);
         Title = est.Method ?? string.Empty;
         Status = est.Warnings.Count > 0 ? "Terminated" : "Successful";
+        EstTime = FmtSeconds(est.EstimationTime);
+        CovTime = FmtSeconds(est.CovarianceTime);
         Ofv = est.Ofv?.ToString("0.000", CultureInfo.InvariantCulture) ?? string.Empty;
         ConditionNumber = est.ConditionNumber?.ToString("0.###", CultureInfo.InvariantCulture) ?? string.Empty;
 
@@ -24,9 +29,29 @@ public sealed class EstimationStepViewModel
         Warnings = est.Warnings;
     }
 
-    public int Step { get; }
+    /// <summary>Run-level timing row (no parameters); the value is shown in the Est Time column.</summary>
+    public EstimationStepViewModel(string title, string value)
+    {
+        IsEstimation = false;
+        Step = string.Empty;
+        Title = title;
+        Status = string.Empty;
+        EstTime = value;
+        CovTime = string.Empty;
+        Ofv = string.Empty;
+        ConditionNumber = string.Empty;
+        Thetas = [];
+        Omegas = [];
+        Sigmas = [];
+        Warnings = [];
+    }
+
+    public bool IsEstimation { get; }
+    public string Step { get; }
     public string Title { get; }
     public string Status { get; }
+    public string EstTime { get; }
+    public string CovTime { get; }
     public string Ofv { get; }
     public string ConditionNumber { get; }
     public IReadOnlyList<ParameterRowViewModel> Thetas { get; }
@@ -34,5 +59,8 @@ public sealed class EstimationStepViewModel
     public IReadOnlyList<ParameterRowViewModel> Sigmas { get; }
     public IReadOnlyList<string> Warnings { get; }
 
-    public override string ToString() => $"{Step}: {Title}";
+    private static string FmtSeconds(double? v) =>
+        v.HasValue ? v.Value.ToString("0.##", CultureInfo.InvariantCulture) : string.Empty;
+
+    public override string ToString() => IsEstimation ? $"{Step}: {Title}" : Title;
 }

--- a/src/Census.App/ViewModels/EstimationStepViewModel.cs
+++ b/src/Census.App/ViewModels/EstimationStepViewModel.cs
@@ -4,21 +4,21 @@ using Census.Domain;
 namespace Census.App.ViewModels;
 
 /// <summary>
-/// A row in the bottom-left "Estimation" grid. Most rows are estimation steps (selecting
-/// one drives the parameter tabs). The grid also carries run-level timing rows
-/// (start/stop time, total CPU time, post-processing times) appended after the steps.
+/// One estimation ($EST) step shown in the bottom-left "Estimation" grid. Selecting a
+/// step drives the parameter tabs (theta/omega/sigma) on the right. Post-process and
+/// final-output times are per-problem values, shown on every step row of the run.
 /// </summary>
 public sealed class EstimationStepViewModel
 {
-    /// <summary>Estimation-step row.</summary>
-    public EstimationStepViewModel(Estimation est)
+    public EstimationStepViewModel(Estimation est, string postTime, string finalOutTime)
     {
-        IsEstimation = true;
         Step = est.Number.ToString(CultureInfo.InvariantCulture);
         Title = est.Method ?? string.Empty;
         Status = est.Warnings.Count > 0 ? "Terminated" : "Successful";
         EstTime = FmtSeconds(est.EstimationTime);
         CovTime = FmtSeconds(est.CovarianceTime);
+        PostTime = postTime;
+        FinalOutTime = finalOutTime;
         Ofv = est.Ofv?.ToString("0.000", CultureInfo.InvariantCulture) ?? string.Empty;
         ConditionNumber = est.ConditionNumber?.ToString("0.###", CultureInfo.InvariantCulture) ?? string.Empty;
 
@@ -29,29 +29,13 @@ public sealed class EstimationStepViewModel
         Warnings = est.Warnings;
     }
 
-    /// <summary>Run-level timing row (no parameters); the value is shown in the Est Time column.</summary>
-    public EstimationStepViewModel(string title, string value)
-    {
-        IsEstimation = false;
-        Step = string.Empty;
-        Title = title;
-        Status = string.Empty;
-        EstTime = value;
-        CovTime = string.Empty;
-        Ofv = string.Empty;
-        ConditionNumber = string.Empty;
-        Thetas = [];
-        Omegas = [];
-        Sigmas = [];
-        Warnings = [];
-    }
-
-    public bool IsEstimation { get; }
     public string Step { get; }
     public string Title { get; }
     public string Status { get; }
     public string EstTime { get; }
     public string CovTime { get; }
+    public string PostTime { get; }
+    public string FinalOutTime { get; }
     public string Ofv { get; }
     public string ConditionNumber { get; }
     public IReadOnlyList<ParameterRowViewModel> Thetas { get; }
@@ -59,8 +43,8 @@ public sealed class EstimationStepViewModel
     public IReadOnlyList<ParameterRowViewModel> Sigmas { get; }
     public IReadOnlyList<string> Warnings { get; }
 
-    private static string FmtSeconds(double? v) =>
+    internal static string FmtSeconds(double? v) =>
         v.HasValue ? v.Value.ToString("0.##", CultureInfo.InvariantCulture) : string.Empty;
 
-    public override string ToString() => IsEstimation ? $"{Step}: {Title}" : Title;
+    public override string ToString() => $"{Step}: {Title}";
 }

--- a/src/Census.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Census.App/ViewModels/MainWindowViewModel.cs
@@ -1,9 +1,103 @@
+using System.Collections.ObjectModel;
+using Census.App.Services;
+using Census.Domain;
+using Census.Storage;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 
 namespace Census.App.ViewModels;
 
 public partial class MainWindowViewModel : ObservableObject
 {
+    private readonly IProjectStore _store;
+    private readonly IDialogService _dialogs;
+    private readonly ISettingsService _settings;
+
+    public MainWindowViewModel(IProjectStore store, IDialogService dialogs, ISettingsService settings)
+    {
+        _store = store;
+        _dialogs = dialogs;
+        _settings = settings;
+    }
+
     [ObservableProperty]
-    private string _greeting = "Census — Avalonia scaffold ready.";
+    [NotifyPropertyChangedFor(nameof(Title))]
+    [NotifyPropertyChangedFor(nameof(StatusText))]
+    [NotifyPropertyChangedFor(nameof(IsProjectOpen))]
+    private string? _projectPath;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(StatusText))]
+    private ObservableCollection<RunSummaryViewModel> _runs = [];
+
+    [ObservableProperty]
+    private RunSummaryViewModel? _selectedRun;
+
+    public bool IsProjectOpen => ProjectPath is not null;
+    public string Title => ProjectPath is not null
+        ? $"Census — {Path.GetFileName(ProjectPath)}"
+        : "Census";
+    public string StatusText => ProjectPath is not null
+        ? $"{Runs.Count} run{(Runs.Count == 1 ? "" : "s")} | {Path.GetFileName(ProjectPath)}"
+        : "No project open";
+
+    [RelayCommand]
+    private async Task NewProjectAsync()
+    {
+        var path = await _dialogs.CreateProjectAsync();
+        if (path is null) return;
+        _store.Create(path);
+        ProjectPath = path;
+        Runs.Clear();
+        _settings.AddRecentProject(path);
+    }
+
+    [RelayCommand]
+    private async Task OpenProjectAsync()
+    {
+        var path = await _dialogs.OpenProjectAsync();
+        if (path is null) return;
+        LoadProject(path);
+    }
+
+    [RelayCommand]
+    private void CloseProject()
+    {
+        ProjectPath = null;
+        Runs.Clear();
+    }
+
+    [RelayCommand]
+    private void Exit()
+    {
+        if (Avalonia.Application.Current?.ApplicationLifetime is
+            Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime lifetime)
+            lifetime.Shutdown();
+    }
+
+    private void LoadProject(string path)
+    {
+        try
+        {
+            _store.Open(path);
+            ProjectPath = path;
+            RefreshRuns();
+            _settings.AddRecentProject(path);
+        }
+        catch (Exception ex)
+        {
+            // TODO: show error dialog when compare/import dialogs are implemented in Task 3
+            System.Diagnostics.Debug.WriteLine($"Failed to open project: {ex.Message}");
+        }
+    }
+
+    private void RefreshRuns()
+    {
+        var all = _store.GetRuns();
+        var byRunNo = all.ToDictionary(r => r.RunNo, r => r);
+        Runs = new ObservableCollection<RunSummaryViewModel>(
+            all.Select(r => new RunSummaryViewModel(r, byRunNo)));
+        OnPropertyChanged(nameof(Runs));
+        OnPropertyChanged(nameof(StatusText));
+    }
 }

--- a/src/Census.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Census.App/ViewModels/MainWindowViewModel.cs
@@ -1,6 +1,8 @@
 using System.Collections.ObjectModel;
 using System.IO;
+using Avalonia.Controls.ApplicationLifetimes;
 using Census.App.Services;
+using Census.App.Views;
 using Census.Archive;
 using Census.Domain;
 using Census.Import;
@@ -22,6 +24,7 @@ public partial class MainWindowViewModel : ObservableObject
         _store = store;
         _dialogs = dialogs;
         _settings = settings;
+        RefreshRecentProjects();
     }
 
     [ObservableProperty]
@@ -30,6 +33,9 @@ public partial class MainWindowViewModel : ObservableObject
     [NotifyCanExecuteChangedFor(nameof(ImportRunCommand))]
     [NotifyCanExecuteChangedFor(nameof(ImportFolderCommand))]
     private string? _projectPath;
+
+    [ObservableProperty]
+    private ObservableCollection<string> _recentProjects = [];
 
     [ObservableProperty]
     private ObservableCollection<RunSummaryViewModel> _runs = [];
@@ -70,6 +76,7 @@ public partial class MainWindowViewModel : ObservableObject
         ProjectPath = path;
         Runs.Clear();
         _settings.AddRecentProject(path);
+        RefreshRecentProjects();
         UpdateStatusText($"0 runs | {Path.GetFileName(path)}");
     }
 
@@ -162,6 +169,33 @@ public partial class MainWindowViewModel : ObservableObject
         UpdateStatusText($"Archived {SelectedRun.RunNo} to {Path.GetFileName(path)}.");
     }
 
+    [RelayCommand]
+    private async Task OpenRecentProjectAsync(string path)
+    {
+        if (!File.Exists(path))
+        {
+            UpdateStatusText($"Project not found: {Path.GetFileName(path)}");
+            return;
+        }
+        LoadProject(path);
+        await Task.CompletedTask;
+    }
+
+    [RelayCommand]
+    private async Task OpenSettingsAsync()
+    {
+        var vm = new SettingsViewModel(_settings);
+        var win = new SettingsWindow { DataContext = vm };
+        var owner = (Avalonia.Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.MainWindow;
+        if (owner is not null)
+            await win.ShowDialog(owner);
+    }
+
+    private void RefreshRecentProjects()
+    {
+        RecentProjects = new ObservableCollection<string>(_settings.GetRecentProjects());
+    }
+
     private void LoadProject(string path)
     {
         try
@@ -170,6 +204,7 @@ public partial class MainWindowViewModel : ObservableObject
             ProjectPath = path;
             RefreshRuns();
             _settings.AddRecentProject(path);
+            RefreshRecentProjects();
         }
         catch (Exception ex)
         {

--- a/src/Census.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Census.App/ViewModels/MainWindowViewModel.cs
@@ -1,6 +1,10 @@
 using System.Collections.ObjectModel;
+using System.IO;
 using Census.App.Services;
+using Census.Archive;
 using Census.Domain;
+using Census.Import;
+using Census.Reports;
 using Census.Storage;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -22,15 +26,17 @@ public partial class MainWindowViewModel : ObservableObject
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(Title))]
-    [NotifyPropertyChangedFor(nameof(StatusText))]
     [NotifyPropertyChangedFor(nameof(IsProjectOpen))]
+    [NotifyCanExecuteChangedFor(nameof(ImportRunCommand))]
+    [NotifyCanExecuteChangedFor(nameof(ImportFolderCommand))]
     private string? _projectPath;
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(StatusText))]
     private ObservableCollection<RunSummaryViewModel> _runs = [];
 
     [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(ExportRunCommand))]
+    [NotifyCanExecuteChangedFor(nameof(ArchiveRunCommand))]
     private RunSummaryViewModel? _selectedRun;
 
     [ObservableProperty]
@@ -42,12 +48,18 @@ public partial class MainWindowViewModel : ObservableObject
     }
 
     public bool IsProjectOpen => ProjectPath is not null;
+    public bool IsRunSelected => SelectedRun is not null;
+
     public string Title => ProjectPath is not null
         ? $"Census — {Path.GetFileName(ProjectPath)}"
         : "Census";
-    public string StatusText => ProjectPath is not null
-        ? $"{Runs.Count} run{(Runs.Count == 1 ? "" : "s")} | {Path.GetFileName(ProjectPath)}"
-        : "No project open";
+    public string StatusText { get; private set; } = "No project open";
+
+    private void UpdateStatusText(string text)
+    {
+        StatusText = text;
+        OnPropertyChanged(nameof(StatusText));
+    }
 
     [RelayCommand]
     private async Task NewProjectAsync()
@@ -58,6 +70,7 @@ public partial class MainWindowViewModel : ObservableObject
         ProjectPath = path;
         Runs.Clear();
         _settings.AddRecentProject(path);
+        UpdateStatusText($"0 runs | {Path.GetFileName(path)}");
     }
 
     [RelayCommand]
@@ -73,6 +86,7 @@ public partial class MainWindowViewModel : ObservableObject
     {
         ProjectPath = null;
         Runs.Clear();
+        UpdateStatusText("No project open");
     }
 
     [RelayCommand]
@@ -81,6 +95,71 @@ public partial class MainWindowViewModel : ObservableObject
         if (Avalonia.Application.Current?.ApplicationLifetime is
             Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime lifetime)
             lifetime.Shutdown();
+    }
+
+    [RelayCommand(CanExecute = nameof(IsProjectOpen))]
+    private async Task ImportRunAsync()
+    {
+        var path = await _dialogs.OpenImportFileAsync();
+        if (path is null) return;
+        var run = new NonmemXmlImporter().Import(path);
+        _store.SaveRun(run);
+        RefreshRuns();
+    }
+
+    [RelayCommand(CanExecute = nameof(IsProjectOpen))]
+    private async Task ImportFolderAsync()
+    {
+        var folder = await _dialogs.OpenImportFolderAsync();
+        if (folder is null) return;
+        var importer = new NonmemXmlImporter();
+        var files = Directory.EnumerateFiles(folder, "*.xml", SearchOption.AllDirectories).ToList();
+        int imported = 0;
+        foreach (var file in files)
+        {
+            try
+            {
+                var run = importer.Import(file);
+                _store.SaveRun(run);
+                imported++;
+            }
+            catch { /* skip unparseable files */ }
+        }
+        if (imported > 0) RefreshRuns();
+        UpdateStatusText($"Imported {imported} of {files.Count} XML files.");
+    }
+
+    [RelayCommand(CanExecute = nameof(IsRunSelected))]
+    private async Task ExportRunAsync()
+    {
+        if (SelectedRun is null) return;
+        var path = await _dialogs.SaveReportAsync("csv");
+        if (path is null) return;
+        var ext = Path.GetExtension(path).TrimStart('.').ToLowerInvariant();
+        IReportWriter writer = ext switch
+        {
+            "html" => new HtmlReportWriter(),
+            "tex"  => new LatexReportWriter(),
+            _      => new CsvReportWriter(),
+        };
+        var run = _store.GetRuns().FirstOrDefault(r => r.RunNo == SelectedRun.RunNo);
+        if (run is null) return;
+        var content = writer.Render(run);
+        await File.WriteAllTextAsync(path, content);
+        UpdateStatusText($"Exported {SelectedRun.RunNo} to {Path.GetFileName(path)}.");
+    }
+
+    [RelayCommand(CanExecute = nameof(IsRunSelected))]
+    private async Task ArchiveRunAsync()
+    {
+        if (SelectedRun is null) return;
+        var path = await _dialogs.SaveArchiveAsync("zip");
+        if (path is null) return;
+        var run = _store.GetRuns().FirstOrDefault(r => r.RunNo == SelectedRun.RunNo);
+        if (run is null) return;
+        var archiver = new RunArchiver();
+        await Task.Run(() => archiver.Archive(run, path, includeData: true));
+        UpdateStatusText($"Archived {SelectedRun.RunNo} to {Path.GetFileName(path)}.");
     }
 
     private void LoadProject(string path)
@@ -94,7 +173,6 @@ public partial class MainWindowViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            // TODO: show error dialog when compare/import dialogs are implemented in Task 3
             System.Diagnostics.Debug.WriteLine($"Failed to open project: {ex.Message}");
         }
     }
@@ -106,6 +184,8 @@ public partial class MainWindowViewModel : ObservableObject
         Runs = new ObservableCollection<RunSummaryViewModel>(
             all.Select(r => new RunSummaryViewModel(r, byRunNo)));
         OnPropertyChanged(nameof(Runs));
-        OnPropertyChanged(nameof(StatusText));
+        UpdateStatusText(ProjectPath is not null
+            ? $"{Runs.Count} run{(Runs.Count == 1 ? "" : "s")} | {Path.GetFileName(ProjectPath)}"
+            : "No project open");
     }
 }

--- a/src/Census.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Census.App/ViewModels/MainWindowViewModel.cs
@@ -30,8 +30,10 @@ public partial class MainWindowViewModel : ObservableObject
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(Title))]
     [NotifyPropertyChangedFor(nameof(IsProjectOpen))]
+    [NotifyPropertyChangedFor(nameof(ConnectionStatus))]
     [NotifyCanExecuteChangedFor(nameof(ImportRunCommand))]
     [NotifyCanExecuteChangedFor(nameof(ImportFolderCommand))]
+    [NotifyCanExecuteChangedFor(nameof(CompareCommand))]
     private string? _projectPath;
 
     [ObservableProperty]
@@ -41,8 +43,19 @@ public partial class MainWindowViewModel : ObservableObject
     private ObservableCollection<RunSummaryViewModel> _runs = [];
 
     [ObservableProperty]
+    private ObservableCollection<RunTreeNode> _runTree = [];
+
+    [ObservableProperty]
+    private RunTreeNode? _selectedTreeNode;
+
+    [ObservableProperty]
+    private bool _treeExpanded = true;
+
+    [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(ExportRunCommand))]
     [NotifyCanExecuteChangedFor(nameof(ArchiveRunCommand))]
+    [NotifyCanExecuteChangedFor(nameof(DeleteRunCommand))]
+    [NotifyCanExecuteChangedFor(nameof(DiagnosticsCommand))]
     private RunSummaryViewModel? _selectedRun;
 
     [ObservableProperty]
@@ -53,12 +66,29 @@ public partial class MainWindowViewModel : ObservableObject
         RunDetail = value is not null ? new RunDetailViewModel(value.Model) : null;
     }
 
+    partial void OnSelectedTreeNodeChanged(RunTreeNode? value)
+    {
+        if (value?.Run is not null)
+            SelectedRun = value.Run;
+    }
+
+    partial void OnTreeExpandedChanged(bool value)
+    {
+        foreach (var node in RunTree)
+            node.IsExpanded = value;
+    }
+
     public bool IsProjectOpen => ProjectPath is not null;
     public bool IsRunSelected => SelectedRun is not null;
 
     public string Title => ProjectPath is not null
         ? $"Census — {Path.GetFileName(ProjectPath)}"
         : "Census";
+
+    public string ConnectionStatus => ProjectPath is not null
+        ? $"Connected – {ProjectPath}"
+        : "Not connected";
+
     public string StatusText { get; private set; } = "No project open";
 
     private void UpdateStatusText(string text)
@@ -74,10 +104,9 @@ public partial class MainWindowViewModel : ObservableObject
         if (path is null) return;
         _store.Create(path);
         ProjectPath = path;
-        Runs.Clear();
+        RefreshRuns();
         _settings.AddRecentProject(path);
         RefreshRecentProjects();
-        UpdateStatusText($"0 runs | {Path.GetFileName(path)}");
     }
 
     [RelayCommand]
@@ -91,8 +120,10 @@ public partial class MainWindowViewModel : ObservableObject
     [RelayCommand]
     private void CloseProject()
     {
+        SelectedRun = null;
         ProjectPath = null;
         Runs.Clear();
+        RunTree = [];
         UpdateStatusText("No project open");
     }
 
@@ -135,6 +166,25 @@ public partial class MainWindowViewModel : ObservableObject
         if (imported > 0) RefreshRuns();
         UpdateStatusText($"Imported {imported} of {files.Count} XML files.");
     }
+
+    [RelayCommand(CanExecute = nameof(IsRunSelected))]
+    private void DeleteRun()
+    {
+        if (SelectedRun is null) return;
+        var runNo = SelectedRun.RunNo;
+        _store.DeleteRun(runNo);
+        SelectedRun = null;
+        RefreshRuns();
+        UpdateStatusText($"Deleted run {runNo}.");
+    }
+
+    [RelayCommand(CanExecute = nameof(IsProjectOpen))]
+    private void Compare() =>
+        UpdateStatusText("Compare: use the run list to review runs side by side (full compare view is planned).");
+
+    [RelayCommand(CanExecute = nameof(IsRunSelected))]
+    private void Diagnostics() =>
+        UpdateStatusText("Diagnostics view is planned.");
 
     [RelayCommand(CanExecute = nameof(IsRunSelected))]
     private async Task ExportRunAsync()
@@ -219,8 +269,20 @@ public partial class MainWindowViewModel : ObservableObject
         Runs = new ObservableCollection<RunSummaryViewModel>(
             all.Select(r => new RunSummaryViewModel(r, byRunNo)));
         OnPropertyChanged(nameof(Runs));
+        RebuildRunTree();
         UpdateStatusText(ProjectPath is not null
             ? $"{Runs.Count} run{(Runs.Count == 1 ? "" : "s")} | {Path.GetFileName(ProjectPath)}"
             : "No project open");
+    }
+
+    private void RebuildRunTree()
+    {
+        var root = new RunTreeNode("All runs", null) { IsExpanded = TreeExpanded };
+        foreach (var run in Runs)
+        {
+            var label = string.IsNullOrEmpty(run.Comment) ? run.RunNo : $"{run.RunNo}  —  {run.Comment}";
+            root.Children.Add(new RunTreeNode(label, run));
+        }
+        RunTree = [root];
     }
 }

--- a/src/Census.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Census.App/ViewModels/MainWindowViewModel.cs
@@ -33,6 +33,14 @@ public partial class MainWindowViewModel : ObservableObject
     [ObservableProperty]
     private RunSummaryViewModel? _selectedRun;
 
+    [ObservableProperty]
+    private RunDetailViewModel? _runDetail;
+
+    partial void OnSelectedRunChanged(RunSummaryViewModel? value)
+    {
+        RunDetail = value is not null ? new RunDetailViewModel(value.Model) : null;
+    }
+
     public bool IsProjectOpen => ProjectPath is not null;
     public string Title => ProjectPath is not null
         ? $"Census — {Path.GetFileName(ProjectPath)}"

--- a/src/Census.App/ViewModels/ParameterRowViewModel.cs
+++ b/src/Census.App/ViewModels/ParameterRowViewModel.cs
@@ -1,0 +1,40 @@
+using Census.Domain;
+using Census.Reports;
+using System.Globalization;
+
+namespace Census.App.ViewModels;
+
+public sealed class ParameterRowViewModel
+{
+    public ParameterRowViewModel(Parameter p)
+    {
+        var row = ParameterRow.FromParameter(p);
+        Kind      = row.Kind;
+        Index     = p.Index;
+        Label     = p.Label ?? string.Empty;
+        Estimate  = Fmt(row.Estimate);
+        Se        = Fmt(row.StandardError);
+        Rse       = Fmt(row.Rse);
+        CiLower   = Fmt(row.CiLower);
+        CiUpper   = Fmt(row.CiUpper);
+        Shrinkage = Fmt(row.Shrinkage);
+    }
+
+    private static string Fmt(double? v) =>
+        v.HasValue ? v.Value.ToString("G4", CultureInfo.InvariantCulture) : string.Empty;
+
+    public string Kind      { get; }
+    public int    Index     { get; }
+    public string Label     { get; }
+    public string Estimate  { get; }
+    public string Se        { get; }
+    public string Rse       { get; }
+    public string CiLower   { get; }
+    public string CiUpper   { get; }
+    public string Shrinkage { get; }
+
+    /// <summary>Formatted 95% CI as "lower – upper" or empty.</summary>
+    public string Ci => (CiLower.Length > 0 && CiUpper.Length > 0)
+        ? $"{CiLower} – {CiUpper}"
+        : string.Empty;
+}

--- a/src/Census.App/ViewModels/RunDetailViewModel.cs
+++ b/src/Census.App/ViewModels/RunDetailViewModel.cs
@@ -21,12 +21,29 @@ public sealed partial class RunDetailViewModel : ObservableObject
         Individuals = run.Individuals?.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
         FileCount = run.Files.Count.ToString(CultureInfo.InvariantCulture);
 
-        Estimations = new ObservableCollection<EstimationStepViewModel>(
-            run.Estimations.Select(e => new EstimationStepViewModel(e)));
+        var rows = run.Estimations.Select(e => new EstimationStepViewModel(e)).ToList();
 
-        // Default to the final estimation step, as the original UI does.
-        SelectedEstimation = Estimations.Count > 0 ? Estimations[^1] : null;
+        // Run-level timing values appear as extra rows after the estimation steps.
+        AddTimingRow(rows, "Start time", run.StartDateTime);
+        AddTimingRow(rows, "Stop time", run.StopDateTime);
+        AddTimingRow(rows, "Total CPU time", FmtSeconds(run.TotalCpuTime));
+        AddTimingRow(rows, "Post-process time", FmtSeconds(run.PostElapsedTime));
+        AddTimingRow(rows, "Final output time", FmtSeconds(run.FinalOutputElapsedTime));
+
+        Estimations = new ObservableCollection<EstimationStepViewModel>(rows);
+
+        // Default to the final estimation step (not a timing row), as the original UI does.
+        SelectedEstimation = Estimations.LastOrDefault(r => r.IsEstimation) ?? Estimations.FirstOrDefault();
     }
+
+    private static void AddTimingRow(List<EstimationStepViewModel> rows, string label, string? value)
+    {
+        if (!string.IsNullOrEmpty(value))
+            rows.Add(new EstimationStepViewModel(label, value));
+    }
+
+    private static string? FmtSeconds(double? v) =>
+        v.HasValue ? v.Value.ToString("0.##", CultureInfo.InvariantCulture) : null;
 
     public string RunNo { get; }
     public string ParentNo { get; }

--- a/src/Census.App/ViewModels/RunDetailViewModel.cs
+++ b/src/Census.App/ViewModels/RunDetailViewModel.cs
@@ -1,50 +1,42 @@
-using Census.Domain;
+using System.Collections.ObjectModel;
 using System.Globalization;
+using Census.Domain;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace Census.App.ViewModels;
 
-public sealed class RunDetailViewModel
+/// <summary>
+/// Drives the bottom region of the main window: the "Estimation" steps grid on the
+/// left and the parameter tabs (theta/omega/sigma/…) on the right, which follow the
+/// currently selected estimation step.
+/// </summary>
+public sealed partial class RunDetailViewModel : ObservableObject
 {
     public RunDetailViewModel(Run run)
     {
         RunNo = run.RunNo;
+        ParentNo = run.ParentNo ?? string.Empty;
+        Comment = run.Comment ?? string.Empty;
+        ObsRecs = run.ObsRecs?.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
+        Individuals = run.Individuals?.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
+        FileCount = run.Files.Count.ToString(CultureInfo.InvariantCulture);
 
-        var lastEst = run.Estimations.Count > 0 ? run.Estimations[^1] : null;
+        Estimations = new ObservableCollection<EstimationStepViewModel>(
+            run.Estimations.Select(e => new EstimationStepViewModel(e)));
 
-        Method          = lastEst?.Method ?? string.Empty;
-        Ofv             = lastEst?.Ofv?.ToString("0.000", CultureInfo.InvariantCulture) ?? string.Empty;
-        ConditionNumber = lastEst?.ConditionNumber?.ToString("0", CultureInfo.InvariantCulture) ?? string.Empty;
-        ObsRecs         = run.ObsRecs?.ToString() ?? string.Empty;
-        Individuals     = run.Individuals?.ToString() ?? string.Empty;
-
-        Warnings = lastEst?.Warnings ?? [];
-
-        var parameters  = lastEst?.Parameters ?? [];
-        Thetas  = parameters.Where(p => p.Kind == ParameterKind.Theta).Select(p => new ParameterRowViewModel(p)).ToList();
-        Omegas  = parameters.Where(p => p.Kind == ParameterKind.Omega).Select(p => new ParameterRowViewModel(p)).ToList();
-        Sigmas  = parameters.Where(p => p.Kind == ParameterKind.Sigma).Select(p => new ParameterRowViewModel(p)).ToList();
-
-        AllParameters = parameters.Select(p => new ParameterRowViewModel(p)).ToList();
-
-        EstimationCount = run.Estimations.Count;
-        HasMultipleEstimations = run.Estimations.Count > 1;
+        // Default to the final estimation step, as the original UI does.
+        SelectedEstimation = Estimations.Count > 0 ? Estimations[^1] : null;
     }
 
-    public string RunNo             { get; }
-    public string Method            { get; }
-    public string Ofv               { get; }
-    public string ConditionNumber   { get; }
-    public string ObsRecs           { get; }
-    public string Individuals       { get; }
-    public IReadOnlyList<string>               Warnings      { get; }
-    public IReadOnlyList<ParameterRowViewModel> Thetas        { get; }
-    public IReadOnlyList<ParameterRowViewModel> Omegas        { get; }
-    public IReadOnlyList<ParameterRowViewModel> Sigmas        { get; }
-    public IReadOnlyList<ParameterRowViewModel> AllParameters { get; }
-    public int  EstimationCount        { get; }
-    public bool HasMultipleEstimations { get; }
-    public bool HasWarnings            => Warnings.Count > 0;
-    public bool HasThetas              => Thetas.Count > 0;
-    public bool HasOmegas              => Omegas.Count > 0;
-    public bool HasSigmas              => Sigmas.Count > 0;
+    public string RunNo { get; }
+    public string ParentNo { get; }
+    public string Comment { get; }
+    public string ObsRecs { get; }
+    public string Individuals { get; }
+    public string FileCount { get; }
+
+    public ObservableCollection<EstimationStepViewModel> Estimations { get; }
+
+    [ObservableProperty]
+    private EstimationStepViewModel? _selectedEstimation;
 }

--- a/src/Census.App/ViewModels/RunDetailViewModel.cs
+++ b/src/Census.App/ViewModels/RunDetailViewModel.cs
@@ -21,29 +21,16 @@ public sealed partial class RunDetailViewModel : ObservableObject
         Individuals = run.Individuals?.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
         FileCount = run.Files.Count.ToString(CultureInfo.InvariantCulture);
 
-        var rows = run.Estimations.Select(e => new EstimationStepViewModel(e)).ToList();
+        // Post-process and final-output times are per-problem; shown on every step row.
+        var postTime = EstimationStepViewModel.FmtSeconds(run.PostElapsedTime);
+        var finalOutTime = EstimationStepViewModel.FmtSeconds(run.FinalOutputElapsedTime);
 
-        // Run-level timing values appear as extra rows after the estimation steps.
-        AddTimingRow(rows, "Start time", run.StartDateTime);
-        AddTimingRow(rows, "Stop time", run.StopDateTime);
-        AddTimingRow(rows, "Total CPU time", FmtSeconds(run.TotalCpuTime));
-        AddTimingRow(rows, "Post-process time", FmtSeconds(run.PostElapsedTime));
-        AddTimingRow(rows, "Final output time", FmtSeconds(run.FinalOutputElapsedTime));
+        Estimations = new ObservableCollection<EstimationStepViewModel>(
+            run.Estimations.Select(e => new EstimationStepViewModel(e, postTime, finalOutTime)));
 
-        Estimations = new ObservableCollection<EstimationStepViewModel>(rows);
-
-        // Default to the final estimation step (not a timing row), as the original UI does.
-        SelectedEstimation = Estimations.LastOrDefault(r => r.IsEstimation) ?? Estimations.FirstOrDefault();
+        // Default to the final estimation step, as the original UI does.
+        SelectedEstimation = Estimations.Count > 0 ? Estimations[^1] : null;
     }
-
-    private static void AddTimingRow(List<EstimationStepViewModel> rows, string label, string? value)
-    {
-        if (!string.IsNullOrEmpty(value))
-            rows.Add(new EstimationStepViewModel(label, value));
-    }
-
-    private static string? FmtSeconds(double? v) =>
-        v.HasValue ? v.Value.ToString("0.##", CultureInfo.InvariantCulture) : null;
 
     public string RunNo { get; }
     public string ParentNo { get; }

--- a/src/Census.App/ViewModels/RunDetailViewModel.cs
+++ b/src/Census.App/ViewModels/RunDetailViewModel.cs
@@ -1,0 +1,50 @@
+using Census.Domain;
+using System.Globalization;
+
+namespace Census.App.ViewModels;
+
+public sealed class RunDetailViewModel
+{
+    public RunDetailViewModel(Run run)
+    {
+        RunNo = run.RunNo;
+
+        var lastEst = run.Estimations.Count > 0 ? run.Estimations[^1] : null;
+
+        Method          = lastEst?.Method ?? string.Empty;
+        Ofv             = lastEst?.Ofv?.ToString("0.000", CultureInfo.InvariantCulture) ?? string.Empty;
+        ConditionNumber = lastEst?.ConditionNumber?.ToString("0", CultureInfo.InvariantCulture) ?? string.Empty;
+        ObsRecs         = run.ObsRecs?.ToString() ?? string.Empty;
+        Individuals     = run.Individuals?.ToString() ?? string.Empty;
+
+        Warnings = lastEst?.Warnings ?? [];
+
+        var parameters  = lastEst?.Parameters ?? [];
+        Thetas  = parameters.Where(p => p.Kind == ParameterKind.Theta).Select(p => new ParameterRowViewModel(p)).ToList();
+        Omegas  = parameters.Where(p => p.Kind == ParameterKind.Omega).Select(p => new ParameterRowViewModel(p)).ToList();
+        Sigmas  = parameters.Where(p => p.Kind == ParameterKind.Sigma).Select(p => new ParameterRowViewModel(p)).ToList();
+
+        AllParameters = parameters.Select(p => new ParameterRowViewModel(p)).ToList();
+
+        EstimationCount = run.Estimations.Count;
+        HasMultipleEstimations = run.Estimations.Count > 1;
+    }
+
+    public string RunNo             { get; }
+    public string Method            { get; }
+    public string Ofv               { get; }
+    public string ConditionNumber   { get; }
+    public string ObsRecs           { get; }
+    public string Individuals       { get; }
+    public IReadOnlyList<string>               Warnings      { get; }
+    public IReadOnlyList<ParameterRowViewModel> Thetas        { get; }
+    public IReadOnlyList<ParameterRowViewModel> Omegas        { get; }
+    public IReadOnlyList<ParameterRowViewModel> Sigmas        { get; }
+    public IReadOnlyList<ParameterRowViewModel> AllParameters { get; }
+    public int  EstimationCount        { get; }
+    public bool HasMultipleEstimations { get; }
+    public bool HasWarnings            => Warnings.Count > 0;
+    public bool HasThetas              => Thetas.Count > 0;
+    public bool HasOmegas              => Omegas.Count > 0;
+    public bool HasSigmas              => Sigmas.Count > 0;
+}

--- a/src/Census.App/ViewModels/RunSummaryViewModel.cs
+++ b/src/Census.App/ViewModels/RunSummaryViewModel.cs
@@ -1,3 +1,4 @@
+using Avalonia.Media;
 using Census.Domain;
 
 namespace Census.App.ViewModels;
@@ -13,6 +14,7 @@ public sealed class RunSummaryViewModel
         var lastEst = run.Estimations.Count > 0 ? run.Estimations[^1] : null;
         RunNo = run.RunNo;
         ParentNo = run.ParentNo ?? string.Empty;
+        Comment = run.Comment ?? string.Empty;
         Method = lastEst?.Method ?? string.Empty;
         Ofv = lastEst?.Ofv?.ToString("0.000", System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty;
 
@@ -40,6 +42,7 @@ public sealed class RunSummaryViewModel
 
     public string RunNo { get; }
     public string ParentNo { get; }
+    public string Comment { get; }
     public string Method { get; }
     public string Ofv { get; }
     public string DOfv { get; }
@@ -49,4 +52,13 @@ public sealed class RunSummaryViewModel
     public bool KeyRun { get; }
     public int WarningCount { get; }
     public string Warnings => WarningCount > 0 ? WarningCount.ToString() : string.Empty;
+
+    /// <summary>Status circle in the run list: green = key run, red = has warnings, else none.</summary>
+    public IBrush FlagBrush => KeyRun
+        ? Brushes.MediumSeaGreen
+        : WarningCount > 0 ? Brushes.IndianRed : Brushes.Transparent;
+
+    /// <summary>dOFV is shown in red when it is non-zero (matches the original Census UI).</summary>
+    public IBrush DOfvBrush =>
+        DOfv.StartsWith('+') || DOfv.StartsWith('-') ? Brushes.Firebrick : Brushes.Black;
 }

--- a/src/Census.App/ViewModels/RunSummaryViewModel.cs
+++ b/src/Census.App/ViewModels/RunSummaryViewModel.cs
@@ -1,0 +1,52 @@
+using Census.Domain;
+
+namespace Census.App.ViewModels;
+
+public sealed class RunSummaryViewModel
+{
+    public Run Model { get; }
+
+    public RunSummaryViewModel(Run run, IReadOnlyDictionary<string, Run> allByRunNo)
+    {
+        Model = run;
+
+        var lastEst = run.Estimations.Count > 0 ? run.Estimations[^1] : null;
+        RunNo = run.RunNo;
+        ParentNo = run.ParentNo ?? string.Empty;
+        Method = lastEst?.Method ?? string.Empty;
+        Ofv = lastEst?.Ofv?.ToString("0.000", System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty;
+
+        // Compute dOFV relative to parent
+        if (run.ParentNo is not null
+            && allByRunNo.TryGetValue(run.ParentNo, out var parent)
+            && lastEst?.Ofv.HasValue == true
+            && parent.Estimations.Count > 0
+            && parent.Estimations[^1].Ofv.HasValue)
+        {
+            var delta = lastEst.Ofv!.Value - parent.Estimations[^1].Ofv!.Value;
+            DOfv = delta.ToString("+0.000;-0.000;0.000", System.Globalization.CultureInfo.InvariantCulture);
+        }
+        else
+        {
+            DOfv = string.Empty;
+        }
+
+        ConditionNumber = lastEst?.ConditionNumber?.ToString("0", System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty;
+        ObsRecs = run.ObsRecs?.ToString() ?? string.Empty;
+        Individuals = run.Individuals?.ToString() ?? string.Empty;
+        KeyRun = run.KeyRun;
+        WarningCount = run.Estimations.Sum(e => e.Warnings.Count);
+    }
+
+    public string RunNo { get; }
+    public string ParentNo { get; }
+    public string Method { get; }
+    public string Ofv { get; }
+    public string DOfv { get; }
+    public string ConditionNumber { get; }
+    public string ObsRecs { get; }
+    public string Individuals { get; }
+    public bool KeyRun { get; }
+    public int WarningCount { get; }
+    public string Warnings => WarningCount > 0 ? WarningCount.ToString() : string.Empty;
+}

--- a/src/Census.App/ViewModels/RunSummaryViewModel.cs
+++ b/src/Census.App/ViewModels/RunSummaryViewModel.cs
@@ -38,6 +38,11 @@ public sealed class RunSummaryViewModel
         Individuals = run.Individuals?.ToString() ?? string.Empty;
         KeyRun = run.KeyRun;
         WarningCount = run.Estimations.Sum(e => e.Warnings.Count);
+
+        // Run-level timings (apply to the whole run). Show datetimes with a space, not 'T'.
+        StartDateTime = run.StartDateTime?.Replace('T', ' ') ?? string.Empty;
+        StopDateTime = run.StopDateTime?.Replace('T', ' ') ?? string.Empty;
+        TotalCpuTime = run.TotalCpuTime?.ToString("0.##", System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty;
     }
 
     public string RunNo { get; }
@@ -52,6 +57,9 @@ public sealed class RunSummaryViewModel
     public bool KeyRun { get; }
     public int WarningCount { get; }
     public string Warnings => WarningCount > 0 ? WarningCount.ToString() : string.Empty;
+    public string StartDateTime { get; }
+    public string StopDateTime { get; }
+    public string TotalCpuTime { get; }
 
     /// <summary>Status circle in the run list: green = key run, red = has warnings, else none.</summary>
     public IBrush FlagBrush => KeyRun

--- a/src/Census.App/ViewModels/RunTreeNode.cs
+++ b/src/Census.App/ViewModels/RunTreeNode.cs
@@ -1,0 +1,24 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Census.App.ViewModels;
+
+/// <summary>
+/// A node in the left "All runs" navigation tree. The root node has a null
+/// <see cref="Run"/>; leaf nodes carry the run they select when clicked.
+/// </summary>
+public sealed partial class RunTreeNode : ObservableObject
+{
+    public RunTreeNode(string label, RunSummaryViewModel? run)
+    {
+        Label = label;
+        Run = run;
+    }
+
+    public string Label { get; }
+    public RunSummaryViewModel? Run { get; }
+    public ObservableCollection<RunTreeNode> Children { get; } = [];
+
+    [ObservableProperty]
+    private bool _isExpanded = true;
+}

--- a/src/Census.App/ViewModels/SettingsViewModel.cs
+++ b/src/Census.App/ViewModels/SettingsViewModel.cs
@@ -1,3 +1,4 @@
+using Avalonia;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Census.App.Services;
@@ -12,26 +13,34 @@ public sealed partial class SettingsViewModel : ObservableObject
     {
         _settings = settings;
         var s = settings.Load();
-        NonmemPath = s.NonmemPath ?? string.Empty;
-        PsnPath    = s.PsnPath    ?? string.Empty;
-        PerlPath   = s.PerlPath   ?? string.Empty;
-        RPath      = s.RPath      ?? string.Empty;
+        NonmemPath   = s.NonmemPath ?? string.Empty;
+        PsnPath      = s.PsnPath    ?? string.Empty;
+        PerlPath     = s.PerlPath   ?? string.Empty;
+        RPath        = s.RPath      ?? string.Empty;
+        GridFontSize = (decimal)s.GridFontSize;
     }
 
     [ObservableProperty] private string _nonmemPath = string.Empty;
     [ObservableProperty] private string _psnPath    = string.Empty;
     [ObservableProperty] private string _perlPath   = string.Empty;
     [ObservableProperty] private string _rPath      = string.Empty;
+    [ObservableProperty] private decimal _gridFontSize = 11;
 
     [RelayCommand]
     private void Save()
     {
+        var fontSize = (double)GridFontSize;
         _settings.UpdateSettings(s =>
         {
-            s.NonmemPath = NonmemPath;
-            s.PsnPath    = PsnPath;
-            s.PerlPath   = PerlPath;
-            s.RPath      = RPath;
+            s.NonmemPath   = NonmemPath;
+            s.PsnPath      = PsnPath;
+            s.PerlPath     = PerlPath;
+            s.RPath        = RPath;
+            s.GridFontSize = fontSize;
         });
+
+        // Apply the new grid font size live to all open grids.
+        if (Application.Current is { } app)
+            app.Resources["GridFontSize"] = fontSize;
     }
 }

--- a/src/Census.App/ViewModels/SettingsViewModel.cs
+++ b/src/Census.App/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,37 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Census.App.Services;
+
+namespace Census.App.ViewModels;
+
+public sealed partial class SettingsViewModel : ObservableObject
+{
+    private readonly ISettingsService _settings;
+
+    public SettingsViewModel(ISettingsService settings)
+    {
+        _settings = settings;
+        var s = settings.Load();
+        NonmemPath = s.NonmemPath ?? string.Empty;
+        PsnPath    = s.PsnPath    ?? string.Empty;
+        PerlPath   = s.PerlPath   ?? string.Empty;
+        RPath      = s.RPath      ?? string.Empty;
+    }
+
+    [ObservableProperty] private string _nonmemPath = string.Empty;
+    [ObservableProperty] private string _psnPath    = string.Empty;
+    [ObservableProperty] private string _perlPath   = string.Empty;
+    [ObservableProperty] private string _rPath      = string.Empty;
+
+    [RelayCommand]
+    private void Save()
+    {
+        _settings.UpdateSettings(s =>
+        {
+            s.NonmemPath = NonmemPath;
+            s.PsnPath    = PsnPath;
+            s.PerlPath   = PerlPath;
+            s.RPath      = RPath;
+        });
+    }
+}

--- a/src/Census.App/Views/MainWindow.axaml
+++ b/src/Census.App/Views/MainWindow.axaml
@@ -4,43 +4,63 @@
         xmlns:views="using:Census.App.Views"
         x:Class="Census.App.Views.MainWindow"
         x:DataType="vm:MainWindowViewModel"
-        Width="1100" Height="700" MinWidth="800" MinHeight="500"
+        Width="1180" Height="720" MinWidth="900" MinHeight="540"
         Title="{Binding Title}">
+
+  <Window.Styles>
+    <!-- Toolbar buttons: flat, icon over label -->
+    <Style Selector="Button.tool">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderThickness" Value="0" />
+      <Setter Property="Padding" Value="8,4" />
+      <Setter Property="VerticalAlignment" Value="Stretch" />
+    </Style>
+    <Style Selector="Button.tool:pointerover /template/ ContentPresenter">
+      <Setter Property="Background" Value="#D6E4F0" />
+      <Setter Property="CornerRadius" Value="4" />
+    </Style>
+    <Style Selector="Button.tool TextBlock.glyph">
+      <Setter Property="FontFamily" Value="Segoe Fluent Icons,Segoe MDL2 Assets" />
+      <Setter Property="FontSize" Value="20" />
+      <Setter Property="HorizontalAlignment" Value="Center" />
+    </Style>
+    <Style Selector="Button.tool TextBlock.label">
+      <Setter Property="FontSize" Value="11" />
+      <Setter Property="HorizontalAlignment" Value="Center" />
+      <Setter Property="Margin" Value="0,2,0,0" />
+    </Style>
+    <!-- Panel header strip -->
+    <Style Selector="Border.panelHeader">
+      <Setter Property="Background" Value="#E6E6E6" />
+      <Setter Property="BorderBrush" Value="#C8C8C8" />
+      <Setter Property="BorderThickness" Value="0,0,0,1" />
+      <Setter Property="Padding" Value="6,3" />
+    </Style>
+  </Window.Styles>
 
   <DockPanel>
 
-    <!-- Menu -->
+    <!-- Menu (Windows convenience; the toolbar is the primary surface) -->
     <Menu DockPanel.Dock="Top">
       <MenuItem Header="_File">
-        <MenuItem Header="_New Project…" Command="{Binding NewProjectCommand}" />
-        <MenuItem Header="_Open Project…" Command="{Binding OpenProjectCommand}" />
-        <MenuItem Header="Recent Projects" ItemsSource="{Binding RecentProjects}">
+        <MenuItem Header="_New Database…" Command="{Binding NewProjectCommand}" />
+        <MenuItem Header="_Open Database…" Command="{Binding OpenProjectCommand}" />
+        <MenuItem Header="Recent" ItemsSource="{Binding RecentProjects}">
           <MenuItem.ItemTemplate>
             <DataTemplate>
-              <MenuItem Header="{Binding}" Command="{Binding $parent[Window].DataContext.OpenRecentProjectCommand}" CommandParameter="{Binding}" />
+              <MenuItem Header="{Binding}"
+                        Command="{Binding $parent[Window].((vm:MainWindowViewModel)DataContext).OpenRecentProjectCommand}"
+                        CommandParameter="{Binding}" />
             </DataTemplate>
           </MenuItem.ItemTemplate>
         </MenuItem>
         <Separator />
-        <MenuItem Header="_Close Project" Command="{Binding CloseProjectCommand}"
-                  IsEnabled="{Binding IsProjectOpen}" />
-        <Separator />
-        <MenuItem Header="_Import Run…" Command="{Binding ImportRunCommand}" InputGesture="Ctrl+I" />
-        <MenuItem Header="Import _Folder…" Command="{Binding ImportFolderCommand}" />
-        <Separator />
-        <MenuItem Header="_Export Run…" Command="{Binding ExportRunCommand}" InputGesture="Ctrl+E" />
-        <MenuItem Header="_Archive Run…" Command="{Binding ArchiveRunCommand}" />
+        <MenuItem Header="_Close" Command="{Binding CloseProjectCommand}" IsEnabled="{Binding IsProjectOpen}" />
         <Separator />
         <MenuItem Header="E_xit" Command="{Binding ExitCommand}" />
       </MenuItem>
-      <MenuItem Header="_Runs" IsEnabled="{Binding IsProjectOpen}">
-        <MenuItem Header="_Import Run…" Command="{Binding ImportRunCommand}" />
-        <MenuItem Header="Import _Folder…" Command="{Binding ImportFolderCommand}" />
-        <Separator />
-        <MenuItem Header="_Compare Runs"  />
-      </MenuItem>
       <MenuItem Header="_Tools">
-        <MenuItem Header="Settings..." Command="{Binding OpenSettingsCommand}" />
+        <MenuItem Header="_Preferences…" Command="{Binding OpenSettingsCommand}" />
       </MenuItem>
       <MenuItem Header="_Help">
         <MenuItem Header="_About Census" />
@@ -48,62 +68,151 @@
     </Menu>
 
     <!-- Toolbar -->
-    <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Spacing="4"
-                Background="{DynamicResource SystemChromeLowColor}" Height="36">
-      <Button Content="New"    Command="{Binding NewProjectCommand}"   Margin="4,4,0,4" />
-      <Button Content="Open"   Command="{Binding OpenProjectCommand}"  Margin="0,4" />
-      <Separator Width="1" Background="#ccc" Margin="4,6" />
-      <Button Content="Import" Command="{Binding ImportRunCommand}" ToolTip.Tip="Import XML run" Margin="0,4" />
-      <Button Content="Import Folder" Command="{Binding ImportFolderCommand}" ToolTip.Tip="Import all XML runs in folder" Margin="0,4" />
-      <Separator Width="1" Background="#ccc" Margin="4,6" />
-      <Button Content="Export" Command="{Binding ExportRunCommand}" ToolTip.Tip="Export selected run to CSV/HTML/LaTeX" Margin="0,4" />
-      <Button Content="Archive" Command="{Binding ArchiveRunCommand}" ToolTip.Tip="Archive selected run as ZIP" Margin="0,4" />
-    </StackPanel>
+    <Border DockPanel.Dock="Top" Background="#F3F3F3" BorderBrush="#C8C8C8" BorderThickness="0,0,0,1">
+      <StackPanel Orientation="Horizontal" Spacing="2" Margin="4,4">
+        <Button Classes="tool" Command="{Binding NewProjectCommand}" ToolTip.Tip="Create a new database">
+          <StackPanel><TextBlock Classes="glyph" Text="&#xE710;" /><TextBlock Classes="label" Text="New Database" /></StackPanel>
+        </Button>
+        <Button Classes="tool" Command="{Binding OpenProjectCommand}" ToolTip.Tip="Open an existing database">
+          <StackPanel><TextBlock Classes="glyph" Text="&#xE8E5;" /><TextBlock Classes="label" Text="Open Database" /></StackPanel>
+        </Button>
 
-    <!-- Status bar -->
-    <Border DockPanel.Dock="Bottom" Background="{DynamicResource SystemChromeLowColor}" Height="24">
-      <TextBlock Text="{Binding StatusText}" VerticalAlignment="Center" Margin="8,0"
-                 FontSize="11" Foreground="{DynamicResource SystemBaseMediumColor}" />
+        <Rectangle Width="1" Fill="#C8C8C8" Margin="4,4" />
+
+        <Button Classes="tool" Command="{Binding ImportRunCommand}" ToolTip.Tip="Import a NONMEM run">
+          <StackPanel><TextBlock Classes="glyph" Text="&#xE896;" /><TextBlock Classes="label" Text="Import Run" /></StackPanel>
+        </Button>
+        <Button Classes="tool" Command="{Binding ImportFolderCommand}" ToolTip.Tip="Import all runs in a folder">
+          <StackPanel><TextBlock Classes="glyph" Text="&#xE8B7;" /><TextBlock Classes="label" Text="Import Folder" /></StackPanel>
+        </Button>
+        <Button Classes="tool" Command="{Binding DeleteRunCommand}" ToolTip.Tip="Delete the selected run">
+          <StackPanel><TextBlock Classes="glyph" Text="&#xE74D;" /><TextBlock Classes="label" Text="Delete Run" /></StackPanel>
+        </Button>
+
+        <Rectangle Width="1" Fill="#C8C8C8" Margin="4,4" />
+
+        <Button Classes="tool" Command="{Binding CompareCommand}" ToolTip.Tip="Compare runs">
+          <StackPanel><TextBlock Classes="glyph" Text="&#xE8AB;" /><TextBlock Classes="label" Text="Compare" /></StackPanel>
+        </Button>
+        <Button Classes="tool" Command="{Binding DiagnosticsCommand}" ToolTip.Tip="Run diagnostics">
+          <StackPanel><TextBlock Classes="glyph" Text="&#xE9D9;" /><TextBlock Classes="label" Text="Diagnostics" /></StackPanel>
+        </Button>
+        <Button Classes="tool" Command="{Binding ExportRunCommand}" ToolTip.Tip="Export a report for the selected run">
+          <StackPanel><TextBlock Classes="glyph" Text="&#xE7C3;" /><TextBlock Classes="label" Text="Report" /></StackPanel>
+        </Button>
+
+        <Rectangle Width="1" Fill="#C8C8C8" Margin="4,4" />
+
+        <Button Classes="tool" Command="{Binding OpenSettingsCommand}" ToolTip.Tip="Preferences">
+          <StackPanel><TextBlock Classes="glyph" Text="&#xE713;" /><TextBlock Classes="label" Text="Preferences" /></StackPanel>
+        </Button>
+        <Button Classes="tool" Command="{Binding ExitCommand}" ToolTip.Tip="Quit Census">
+          <StackPanel><TextBlock Classes="glyph" Text="&#xE7E8;" /><TextBlock Classes="label" Text="Quit" /></StackPanel>
+        </Button>
+      </StackPanel>
     </Border>
 
-    <!-- Main content split: run list (top) + detail (bottom) -->
-    <Grid RowDefinitions="3*,4,2*">
+    <!-- Status bar -->
+    <Border DockPanel.Dock="Bottom" Background="#F3F3F3" BorderBrush="#C8C8C8" BorderThickness="0,1,0,0" Height="24">
+      <DockPanel Margin="8,0">
+        <TextBlock DockPanel.Dock="Right" Text="{Binding StatusText}" VerticalAlignment="Center"
+                   FontSize="11" Foreground="#666" />
+        <TextBlock Text="{Binding ConnectionStatus}" VerticalAlignment="Center" FontSize="11" />
+      </DockPanel>
+    </Border>
 
-      <!-- Run DataGrid -->
-      <DataGrid Grid.Row="0"
-                ItemsSource="{Binding Runs}"
-                SelectedItem="{Binding SelectedRun}"
-                IsReadOnly="True"
-                GridLinesVisibility="Horizontal"
-                CanUserReorderColumns="True"
-                CanUserResizeColumns="True"
-                AutoGenerateColumns="False">
-        <DataGrid.Columns>
-          <DataGridTextColumn Header="Run"     Binding="{Binding RunNo}"           Width="60"  />
-          <DataGridTextColumn Header="Parent"  Binding="{Binding ParentNo}"        Width="60"  />
-          <DataGridTextColumn Header="Method"  Binding="{Binding Method}"          Width="80"  />
-          <DataGridTextColumn Header="OFV"     Binding="{Binding Ofv}"             Width="100" />
-          <DataGridTextColumn Header="dOFV"    Binding="{Binding DOfv}"            Width="90"  />
-          <DataGridTextColumn Header="Cond#"   Binding="{Binding ConditionNumber}" Width="80"  />
-          <DataGridTextColumn Header="Obs"     Binding="{Binding ObsRecs}"         Width="60"  />
-          <DataGridTextColumn Header="Ind"     Binding="{Binding Individuals}"     Width="50"  />
-          <DataGridCheckBoxColumn Header="Key" Binding="{Binding KeyRun}"          Width="40"  />
-          <DataGridTextColumn Header="Warn"    Binding="{Binding Warnings}"        Width="50"  />
-        </DataGrid.Columns>
-      </DataGrid>
+    <!-- Body: left sidebar | run list + detail -->
+    <Grid ColumnDefinitions="230,4,*">
 
-      <!-- Splitter -->
-      <GridSplitter Grid.Row="1" ResizeDirection="Rows" Background="#ccc"
-                    HorizontalAlignment="Stretch" />
+      <!-- Left sidebar: vertical tab strip + filter tree -->
+      <Grid Grid.Column="0" ColumnDefinitions="22,*" Background="#FAFAFA">
 
-      <!-- Run detail (visible only when a run is selected) -->
-      <ContentControl Grid.Row="2" Content="{Binding RunDetail}">
-        <ContentControl.DataTemplates>
-          <DataTemplate DataType="vm:RunDetailViewModel">
-            <views:RunDetailView />
-          </DataTemplate>
-        </ContentControl.DataTemplates>
-      </ContentControl>
+        <Border Grid.Column="0" Background="#ECECEC" BorderBrush="#C8C8C8" BorderThickness="0,0,1,0">
+          <StackPanel VerticalAlignment="Top" Margin="0,8" Spacing="18">
+            <LayoutTransformControl>
+              <LayoutTransformControl.LayoutTransform><RotateTransform Angle="-90" /></LayoutTransformControl.LayoutTransform>
+              <TextBlock Text="Project Overview" FontSize="11" />
+            </LayoutTransformControl>
+            <LayoutTransformControl>
+              <LayoutTransformControl.LayoutTransform><RotateTransform Angle="-90" /></LayoutTransformControl.LayoutTransform>
+              <TextBlock Text="Run Files" FontSize="11" Foreground="#888" />
+            </LayoutTransformControl>
+          </StackPanel>
+        </Border>
+
+        <DockPanel Grid.Column="1">
+          <Border Classes="panelHeader" DockPanel.Dock="Top">
+            <TextBlock Text="Filter" FontSize="11" FontWeight="SemiBold" />
+          </Border>
+          <CheckBox DockPanel.Dock="Bottom" Content="Expanded" Margin="6,2"
+                    IsChecked="{Binding TreeExpanded}" FontSize="11" />
+          <TreeView ItemsSource="{Binding RunTree}"
+                    SelectedItem="{Binding SelectedTreeNode}"
+                    Background="Transparent">
+            <TreeView.Styles>
+              <Style Selector="TreeViewItem">
+                <Setter Property="IsExpanded" Value="{ReflectionBinding IsExpanded, Mode=TwoWay}" />
+              </Style>
+            </TreeView.Styles>
+            <TreeView.ItemTemplate>
+              <TreeDataTemplate ItemsSource="{Binding Children}" x:DataType="vm:RunTreeNode">
+                <TextBlock Text="{Binding Label}" FontSize="12" />
+              </TreeDataTemplate>
+            </TreeView.ItemTemplate>
+          </TreeView>
+        </DockPanel>
+      </Grid>
+
+      <GridSplitter Grid.Column="1" ResizeDirection="Columns" Background="#C8C8C8" VerticalAlignment="Stretch" />
+
+      <!-- Right: run list (top) + detail (bottom) -->
+      <Grid Grid.Column="2" RowDefinitions="3*,4,2*">
+
+        <DataGrid Grid.Row="0"
+                  ItemsSource="{Binding Runs}"
+                  SelectedItem="{Binding SelectedRun}"
+                  IsReadOnly="True"
+                  GridLinesVisibility="Horizontal"
+                  CanUserReorderColumns="True"
+                  CanUserResizeColumns="True"
+                  AutoGenerateColumns="False">
+          <DataGrid.Columns>
+            <DataGridTextColumn Header="Run" Binding="{Binding RunNo}" Width="80" />
+            <DataGridTemplateColumn Header="Flag" Width="44">
+              <DataGridTemplateColumn.CellTemplate>
+                <DataTemplate x:DataType="vm:RunSummaryViewModel">
+                  <Ellipse Width="12" Height="12" Fill="{Binding FlagBrush}"
+                           HorizontalAlignment="Center" VerticalAlignment="Center" />
+                </DataTemplate>
+              </DataGridTemplateColumn.CellTemplate>
+            </DataGridTemplateColumn>
+            <DataGridTextColumn Header="Comment" Binding="{Binding Comment}" Width="240" />
+            <DataGridTextColumn Header="OFV" Binding="{Binding Ofv}" Width="110" />
+            <DataGridTemplateColumn Header="dOFV" Width="90">
+              <DataGridTemplateColumn.CellTemplate>
+                <DataTemplate x:DataType="vm:RunSummaryViewModel">
+                  <TextBlock Text="{Binding DOfv}" Foreground="{Binding DOfvBrush}"
+                             Margin="8,0" VerticalAlignment="Center" />
+                </DataTemplate>
+              </DataGridTemplateColumn.CellTemplate>
+            </DataGridTemplateColumn>
+            <DataGridTextColumn Header="Parent" Binding="{Binding ParentNo}" Width="70" />
+            <DataGridTextColumn Header="Cond No" Binding="{Binding ConditionNumber}" Width="90" />
+            <DataGridTextColumn Header="Warnings" Binding="{Binding Warnings}" Width="*" />
+          </DataGrid.Columns>
+        </DataGrid>
+
+        <GridSplitter Grid.Row="1" ResizeDirection="Rows" Background="#C8C8C8" HorizontalAlignment="Stretch" />
+
+        <ContentControl Grid.Row="2" Content="{Binding RunDetail}">
+          <ContentControl.DataTemplates>
+            <DataTemplate DataType="vm:RunDetailViewModel">
+              <views:RunDetailView />
+            </DataTemplate>
+          </ContentControl.DataTemplates>
+        </ContentControl>
+
+      </Grid>
 
     </Grid>
 

--- a/src/Census.App/Views/MainWindow.axaml
+++ b/src/Census.App/Views/MainWindow.axaml
@@ -1,6 +1,7 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:Census.App.ViewModels"
+        xmlns:views="using:Census.App.Views"
         x:Class="Census.App.Views.MainWindow"
         x:DataType="vm:MainWindowViewModel"
         Width="1100" Height="700" MinWidth="800" MinHeight="500"
@@ -46,28 +47,46 @@
                  FontSize="11" Foreground="{DynamicResource SystemBaseMediumColor}" />
     </Border>
 
-    <!-- Main content: run DataGrid -->
-    <DataGrid ItemsSource="{Binding Runs}"
-              SelectedItem="{Binding SelectedRun}"
-              IsReadOnly="True"
-              GridLinesVisibility="Horizontal"
-              CanUserReorderColumns="True"
-              CanUserResizeColumns="True"
-              AutoGenerateColumns="False"
-              Margin="0">
-      <DataGrid.Columns>
-        <DataGridTextColumn Header="Run"     Binding="{Binding RunNo}"           Width="60" />
-        <DataGridTextColumn Header="Parent"  Binding="{Binding ParentNo}"        Width="60" />
-        <DataGridTextColumn Header="Method"  Binding="{Binding Method}"          Width="80" />
-        <DataGridTextColumn Header="OFV"     Binding="{Binding Ofv}"             Width="100" />
-        <DataGridTextColumn Header="dOFV"    Binding="{Binding DOfv}"            Width="90" />
-        <DataGridTextColumn Header="Cond#"   Binding="{Binding ConditionNumber}" Width="80" />
-        <DataGridTextColumn Header="Obs"     Binding="{Binding ObsRecs}"         Width="60" />
-        <DataGridTextColumn Header="Ind"     Binding="{Binding Individuals}"     Width="50" />
-        <DataGridCheckBoxColumn Header="Key" Binding="{Binding KeyRun}"          Width="40" />
-        <DataGridTextColumn Header="Warn"    Binding="{Binding Warnings}"        Width="50" />
-      </DataGrid.Columns>
-    </DataGrid>
+    <!-- Main content split: run list (top) + detail (bottom) -->
+    <Grid RowDefinitions="3*,4,2*">
+
+      <!-- Run DataGrid -->
+      <DataGrid Grid.Row="0"
+                ItemsSource="{Binding Runs}"
+                SelectedItem="{Binding SelectedRun}"
+                IsReadOnly="True"
+                GridLinesVisibility="Horizontal"
+                CanUserReorderColumns="True"
+                CanUserResizeColumns="True"
+                AutoGenerateColumns="False">
+        <DataGrid.Columns>
+          <DataGridTextColumn Header="Run"     Binding="{Binding RunNo}"           Width="60"  />
+          <DataGridTextColumn Header="Parent"  Binding="{Binding ParentNo}"        Width="60"  />
+          <DataGridTextColumn Header="Method"  Binding="{Binding Method}"          Width="80"  />
+          <DataGridTextColumn Header="OFV"     Binding="{Binding Ofv}"             Width="100" />
+          <DataGridTextColumn Header="dOFV"    Binding="{Binding DOfv}"            Width="90"  />
+          <DataGridTextColumn Header="Cond#"   Binding="{Binding ConditionNumber}" Width="80"  />
+          <DataGridTextColumn Header="Obs"     Binding="{Binding ObsRecs}"         Width="60"  />
+          <DataGridTextColumn Header="Ind"     Binding="{Binding Individuals}"     Width="50"  />
+          <DataGridCheckBoxColumn Header="Key" Binding="{Binding KeyRun}"          Width="40"  />
+          <DataGridTextColumn Header="Warn"    Binding="{Binding Warnings}"        Width="50"  />
+        </DataGrid.Columns>
+      </DataGrid>
+
+      <!-- Splitter -->
+      <GridSplitter Grid.Row="1" ResizeDirection="Rows" Background="#ccc"
+                    HorizontalAlignment="Stretch" />
+
+      <!-- Run detail (visible only when a run is selected) -->
+      <ContentControl Grid.Row="2" Content="{Binding RunDetail}">
+        <ContentControl.DataTemplates>
+          <DataTemplate DataType="vm:RunDetailViewModel">
+            <views:RunDetailView />
+          </DataTemplate>
+        </ContentControl.DataTemplates>
+      </ContentControl>
+
+    </Grid>
 
   </DockPanel>
 

--- a/src/Census.App/Views/MainWindow.axaml
+++ b/src/Census.App/Views/MainWindow.axaml
@@ -14,6 +14,13 @@
       <MenuItem Header="_File">
         <MenuItem Header="_New Project…" Command="{Binding NewProjectCommand}" />
         <MenuItem Header="_Open Project…" Command="{Binding OpenProjectCommand}" />
+        <MenuItem Header="Recent Projects" ItemsSource="{Binding RecentProjects}">
+          <MenuItem.ItemTemplate>
+            <DataTemplate>
+              <MenuItem Header="{Binding}" Command="{Binding $parent[Window].DataContext.OpenRecentProjectCommand}" CommandParameter="{Binding}" />
+            </DataTemplate>
+          </MenuItem.ItemTemplate>
+        </MenuItem>
         <Separator />
         <MenuItem Header="_Close Project" Command="{Binding CloseProjectCommand}"
                   IsEnabled="{Binding IsProjectOpen}" />
@@ -31,6 +38,9 @@
         <MenuItem Header="Import _Folder…" Command="{Binding ImportFolderCommand}" />
         <Separator />
         <MenuItem Header="_Compare Runs"  />
+      </MenuItem>
+      <MenuItem Header="_Tools">
+        <MenuItem Header="Settings..." Command="{Binding OpenSettingsCommand}" />
       </MenuItem>
       <MenuItem Header="_Help">
         <MenuItem Header="_About Census" />

--- a/src/Census.App/Views/MainWindow.axaml
+++ b/src/Census.App/Views/MainWindow.axaml
@@ -1,17 +1,74 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="using:Census.App.ViewModels"
-        mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="600"
         x:Class="Census.App.Views.MainWindow"
         x:DataType="vm:MainWindowViewModel"
-        Width="900" Height="600"
-        Title="Census">
+        Width="1100" Height="700" MinWidth="800" MinHeight="500"
+        Title="{Binding Title}">
 
-  <TextBlock Text="{Binding Greeting}"
-             HorizontalAlignment="Center"
-             VerticalAlignment="Center"
-             FontSize="18" />
+  <DockPanel>
+
+    <!-- Menu -->
+    <Menu DockPanel.Dock="Top">
+      <MenuItem Header="_File">
+        <MenuItem Header="_New Project…" Command="{Binding NewProjectCommand}" />
+        <MenuItem Header="_Open Project…" Command="{Binding OpenProjectCommand}" />
+        <Separator />
+        <MenuItem Header="_Close Project" Command="{Binding CloseProjectCommand}"
+                  IsEnabled="{Binding IsProjectOpen}" />
+        <Separator />
+        <MenuItem Header="E_xit" Command="{Binding ExitCommand}" />
+      </MenuItem>
+      <MenuItem Header="_Runs" IsEnabled="{Binding IsProjectOpen}">
+        <MenuItem Header="_Import Run…"   />
+        <MenuItem Header="Import _Folder…" />
+        <Separator />
+        <MenuItem Header="_Compare Runs"  />
+      </MenuItem>
+      <MenuItem Header="_Help">
+        <MenuItem Header="_About Census" />
+      </MenuItem>
+    </Menu>
+
+    <!-- Toolbar -->
+    <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Spacing="4"
+                Background="{DynamicResource SystemChromeLowColor}" Height="36">
+      <Button Content="New"    Command="{Binding NewProjectCommand}"   Margin="4,4,0,4" />
+      <Button Content="Open"   Command="{Binding OpenProjectCommand}"  Margin="0,4" />
+      <Separator Width="1" Background="#ccc" Margin="4,6" />
+      <Button Content="Import" IsEnabled="{Binding IsProjectOpen}"     Margin="0,4" />
+      <Button Content="Export" IsEnabled="{Binding IsProjectOpen}"     Margin="0,4" />
+    </StackPanel>
+
+    <!-- Status bar -->
+    <Border DockPanel.Dock="Bottom" Background="{DynamicResource SystemChromeLowColor}" Height="24">
+      <TextBlock Text="{Binding StatusText}" VerticalAlignment="Center" Margin="8,0"
+                 FontSize="11" Foreground="{DynamicResource SystemBaseMediumColor}" />
+    </Border>
+
+    <!-- Main content: run DataGrid -->
+    <DataGrid ItemsSource="{Binding Runs}"
+              SelectedItem="{Binding SelectedRun}"
+              IsReadOnly="True"
+              GridLinesVisibility="Horizontal"
+              CanUserReorderColumns="True"
+              CanUserResizeColumns="True"
+              AutoGenerateColumns="False"
+              Margin="0">
+      <DataGrid.Columns>
+        <DataGridTextColumn Header="Run"     Binding="{Binding RunNo}"           Width="60" />
+        <DataGridTextColumn Header="Parent"  Binding="{Binding ParentNo}"        Width="60" />
+        <DataGridTextColumn Header="Method"  Binding="{Binding Method}"          Width="80" />
+        <DataGridTextColumn Header="OFV"     Binding="{Binding Ofv}"             Width="100" />
+        <DataGridTextColumn Header="dOFV"    Binding="{Binding DOfv}"            Width="90" />
+        <DataGridTextColumn Header="Cond#"   Binding="{Binding ConditionNumber}" Width="80" />
+        <DataGridTextColumn Header="Obs"     Binding="{Binding ObsRecs}"         Width="60" />
+        <DataGridTextColumn Header="Ind"     Binding="{Binding Individuals}"     Width="50" />
+        <DataGridCheckBoxColumn Header="Key" Binding="{Binding KeyRun}"          Width="40" />
+        <DataGridTextColumn Header="Warn"    Binding="{Binding Warnings}"        Width="50" />
+      </DataGrid.Columns>
+    </DataGrid>
+
+  </DockPanel>
 
 </Window>

--- a/src/Census.App/Views/MainWindow.axaml
+++ b/src/Census.App/Views/MainWindow.axaml
@@ -18,11 +18,17 @@
         <MenuItem Header="_Close Project" Command="{Binding CloseProjectCommand}"
                   IsEnabled="{Binding IsProjectOpen}" />
         <Separator />
+        <MenuItem Header="_Import Run…" Command="{Binding ImportRunCommand}" InputGesture="Ctrl+I" />
+        <MenuItem Header="Import _Folder…" Command="{Binding ImportFolderCommand}" />
+        <Separator />
+        <MenuItem Header="_Export Run…" Command="{Binding ExportRunCommand}" InputGesture="Ctrl+E" />
+        <MenuItem Header="_Archive Run…" Command="{Binding ArchiveRunCommand}" />
+        <Separator />
         <MenuItem Header="E_xit" Command="{Binding ExitCommand}" />
       </MenuItem>
       <MenuItem Header="_Runs" IsEnabled="{Binding IsProjectOpen}">
-        <MenuItem Header="_Import Run…"   />
-        <MenuItem Header="Import _Folder…" />
+        <MenuItem Header="_Import Run…" Command="{Binding ImportRunCommand}" />
+        <MenuItem Header="Import _Folder…" Command="{Binding ImportFolderCommand}" />
         <Separator />
         <MenuItem Header="_Compare Runs"  />
       </MenuItem>
@@ -37,8 +43,11 @@
       <Button Content="New"    Command="{Binding NewProjectCommand}"   Margin="4,4,0,4" />
       <Button Content="Open"   Command="{Binding OpenProjectCommand}"  Margin="0,4" />
       <Separator Width="1" Background="#ccc" Margin="4,6" />
-      <Button Content="Import" IsEnabled="{Binding IsProjectOpen}"     Margin="0,4" />
-      <Button Content="Export" IsEnabled="{Binding IsProjectOpen}"     Margin="0,4" />
+      <Button Content="Import" Command="{Binding ImportRunCommand}" ToolTip.Tip="Import XML run" Margin="0,4" />
+      <Button Content="Import Folder" Command="{Binding ImportFolderCommand}" ToolTip.Tip="Import all XML runs in folder" Margin="0,4" />
+      <Separator Width="1" Background="#ccc" Margin="4,6" />
+      <Button Content="Export" Command="{Binding ExportRunCommand}" ToolTip.Tip="Export selected run to CSV/HTML/LaTeX" Margin="0,4" />
+      <Button Content="Archive" Command="{Binding ArchiveRunCommand}" ToolTip.Tip="Archive selected run as ZIP" Margin="0,4" />
     </StackPanel>
 
     <!-- Status bar -->

--- a/src/Census.App/Views/MainWindow.axaml
+++ b/src/Census.App/Views/MainWindow.axaml
@@ -198,7 +198,10 @@
             </DataGridTemplateColumn>
             <DataGridTextColumn Header="Parent" Binding="{Binding ParentNo}" Width="70" />
             <DataGridTextColumn Header="Cond No" Binding="{Binding ConditionNumber}" Width="90" />
-            <DataGridTextColumn Header="Warnings" Binding="{Binding Warnings}" Width="*" />
+            <DataGridTextColumn Header="Warnings" Binding="{Binding Warnings}" Width="70" />
+            <DataGridTextColumn Header="Start" Binding="{Binding StartDateTime}" Width="140" />
+            <DataGridTextColumn Header="Stop" Binding="{Binding StopDateTime}" Width="140" />
+            <DataGridTextColumn Header="Total CPU" Binding="{Binding TotalCpuTime}" Width="*" />
           </DataGrid.Columns>
         </DataGrid>
 

--- a/src/Census.App/Views/RunDetailView.axaml
+++ b/src/Census.App/Views/RunDetailView.axaml
@@ -1,0 +1,108 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:Census.App.ViewModels"
+             x:Class="Census.App.Views.RunDetailView"
+             x:DataType="vm:RunDetailViewModel">
+
+  <TabControl>
+
+    <!-- Summary tab -->
+    <TabItem Header="Summary">
+      <ScrollViewer>
+        <StackPanel Margin="8" Spacing="4">
+          <TextBlock><Run Text="Run: "/><Run Text="{Binding RunNo}" FontWeight="Bold"/></TextBlock>
+          <TextBlock><Run Text="Method: "/><Run Text="{Binding Method}"/></TextBlock>
+          <TextBlock><Run Text="OFV: "/><Run Text="{Binding Ofv}"/></TextBlock>
+          <TextBlock IsVisible="{Binding ConditionNumber, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+            <Run Text="Condition number: "/><Run Text="{Binding ConditionNumber}"/>
+          </TextBlock>
+          <TextBlock IsVisible="{Binding ObsRecs, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+            <Run Text="Observations: "/><Run Text="{Binding ObsRecs}"/>
+            <Run Text="  Individuals: "/><Run Text="{Binding Individuals}"/>
+          </TextBlock>
+          <ItemsControl IsVisible="{Binding HasWarnings}" ItemsSource="{Binding Warnings}">
+            <ItemsControl.ItemTemplate>
+              <DataTemplate>
+                <TextBlock Text="{Binding}" Foreground="OrangeRed" FontStyle="Italic" />
+              </DataTemplate>
+            </ItemsControl.ItemTemplate>
+          </ItemsControl>
+        </StackPanel>
+      </ScrollViewer>
+    </TabItem>
+
+    <!-- Parameters tab (all) -->
+    <TabItem Header="Parameters">
+      <DataGrid ItemsSource="{Binding AllParameters}"
+                IsReadOnly="True"
+                GridLinesVisibility="Horizontal"
+                AutoGenerateColumns="False">
+        <DataGrid.Columns>
+          <DataGridTextColumn Header="Type"      Binding="{Binding Kind}"     Width="60"  />
+          <DataGridTextColumn Header="No."       Binding="{Binding Index}"    Width="40"  />
+          <DataGridTextColumn Header="Label"     Binding="{Binding Label}"    Width="80"  />
+          <DataGridTextColumn Header="Estimate"  Binding="{Binding Estimate}" Width="100" />
+          <DataGridTextColumn Header="S.E."      Binding="{Binding Se}"       Width="90"  />
+          <DataGridTextColumn Header="%RSE"      Binding="{Binding Rse}"      Width="70"  />
+          <DataGridTextColumn Header="95% CI"    Binding="{Binding Ci}"       Width="160" />
+          <DataGridTextColumn Header="Shrinkage" Binding="{Binding Shrinkage}" Width="90" />
+        </DataGrid.Columns>
+      </DataGrid>
+    </TabItem>
+
+    <!-- Theta tab -->
+    <TabItem Header="Theta" IsVisible="{Binding HasThetas}">
+      <DataGrid ItemsSource="{Binding Thetas}"
+                IsReadOnly="True"
+                GridLinesVisibility="Horizontal"
+                AutoGenerateColumns="False">
+        <DataGrid.Columns>
+          <DataGridTextColumn Header="&#952;"      Binding="{Binding Index}"    Width="40"  />
+          <DataGridTextColumn Header="Label"    Binding="{Binding Label}"    Width="80"  />
+          <DataGridTextColumn Header="Estimate" Binding="{Binding Estimate}" Width="100" />
+          <DataGridTextColumn Header="S.E."     Binding="{Binding Se}"       Width="90"  />
+          <DataGridTextColumn Header="%RSE"     Binding="{Binding Rse}"      Width="70"  />
+          <DataGridTextColumn Header="95% CI"   Binding="{Binding Ci}"       Width="160" />
+        </DataGrid.Columns>
+      </DataGrid>
+    </TabItem>
+
+    <!-- Omega tab -->
+    <TabItem Header="Omega" IsVisible="{Binding HasOmegas}">
+      <DataGrid ItemsSource="{Binding Omegas}"
+                IsReadOnly="True"
+                GridLinesVisibility="Horizontal"
+                AutoGenerateColumns="False">
+        <DataGrid.Columns>
+          <DataGridTextColumn Header="&#969;&#178;"   Binding="{Binding Index}"    Width="40"  />
+          <DataGridTextColumn Header="Label"     Binding="{Binding Label}"    Width="80"  />
+          <DataGridTextColumn Header="Estimate"  Binding="{Binding Estimate}" Width="100" />
+          <DataGridTextColumn Header="S.E."      Binding="{Binding Se}"       Width="90"  />
+          <DataGridTextColumn Header="%RSE"      Binding="{Binding Rse}"      Width="70"  />
+          <DataGridTextColumn Header="95% CI"    Binding="{Binding Ci}"       Width="160" />
+          <DataGridTextColumn Header="Shrinkage" Binding="{Binding Shrinkage}" Width="90" />
+        </DataGrid.Columns>
+      </DataGrid>
+    </TabItem>
+
+    <!-- Sigma tab -->
+    <TabItem Header="Sigma" IsVisible="{Binding HasSigmas}">
+      <DataGrid ItemsSource="{Binding Sigmas}"
+                IsReadOnly="True"
+                GridLinesVisibility="Horizontal"
+                AutoGenerateColumns="False">
+        <DataGrid.Columns>
+          <DataGridTextColumn Header="&#963;&#178;"   Binding="{Binding Index}"    Width="40"  />
+          <DataGridTextColumn Header="Label"     Binding="{Binding Label}"    Width="80"  />
+          <DataGridTextColumn Header="Estimate"  Binding="{Binding Estimate}" Width="100" />
+          <DataGridTextColumn Header="S.E."      Binding="{Binding Se}"       Width="90"  />
+          <DataGridTextColumn Header="%RSE"      Binding="{Binding Rse}"      Width="70"  />
+          <DataGridTextColumn Header="95% CI"    Binding="{Binding Ci}"       Width="160" />
+          <DataGridTextColumn Header="Shrinkage" Binding="{Binding Shrinkage}" Width="90" />
+        </DataGrid.Columns>
+      </DataGrid>
+    </TabItem>
+
+  </TabControl>
+
+</UserControl>

--- a/src/Census.App/Views/RunDetailView.axaml
+++ b/src/Census.App/Views/RunDetailView.axaml
@@ -31,13 +31,15 @@
                 GridLinesVisibility="Horizontal"
                 AutoGenerateColumns="False">
         <DataGrid.Columns>
-          <DataGridTextColumn Header="Step"     Binding="{Binding Step}"            Width="44"  />
-          <DataGridTextColumn Header="Title"    Binding="{Binding Title}"           Width="*"   />
-          <DataGridTextColumn Header="Status"   Binding="{Binding Status}"          Width="90"  />
-          <DataGridTextColumn Header="Est Time" Binding="{Binding EstTime}"         Width="80"  />
-          <DataGridTextColumn Header="Cov Time" Binding="{Binding CovTime}"         Width="80"  />
-          <DataGridTextColumn Header="OFV"      Binding="{Binding Ofv}"             Width="90"  />
-          <DataGridTextColumn Header="Cond No"  Binding="{Binding ConditionNumber}" Width="70"  />
+          <DataGridTextColumn Header="Step"      Binding="{Binding Step}"            Width="44"  />
+          <DataGridTextColumn Header="Title"     Binding="{Binding Title}"           Width="*"   />
+          <DataGridTextColumn Header="Status"    Binding="{Binding Status}"          Width="90"  />
+          <DataGridTextColumn Header="Est Time"  Binding="{Binding EstTime}"         Width="75"  />
+          <DataGridTextColumn Header="Cov Time"  Binding="{Binding CovTime}"         Width="75"  />
+          <DataGridTextColumn Header="Post Time" Binding="{Binding PostTime}"        Width="75"  />
+          <DataGridTextColumn Header="Final Out" Binding="{Binding FinalOutTime}"    Width="75"  />
+          <DataGridTextColumn Header="OFV"       Binding="{Binding Ofv}"             Width="90"  />
+          <DataGridTextColumn Header="Cond No"   Binding="{Binding ConditionNumber}" Width="70"  />
         </DataGrid.Columns>
       </DataGrid>
     </DockPanel>

--- a/src/Census.App/Views/RunDetailView.axaml
+++ b/src/Census.App/Views/RunDetailView.axaml
@@ -4,105 +4,123 @@
              x:Class="Census.App.Views.RunDetailView"
              x:DataType="vm:RunDetailViewModel">
 
-  <TabControl>
+  <UserControl.Styles>
+    <Style Selector="Border.panelHeader">
+      <Setter Property="Background" Value="#E6E6E6" />
+      <Setter Property="BorderBrush" Value="#C8C8C8" />
+      <Setter Property="BorderThickness" Value="0,0,0,1" />
+      <Setter Property="Padding" Value="6,3" />
+    </Style>
+    <Style Selector="Border.panelHeader > TextBlock">
+      <Setter Property="HorizontalAlignment" Value="Center" />
+      <Setter Property="FontWeight" Value="SemiBold" />
+      <Setter Property="FontSize" Value="11" />
+    </Style>
+  </UserControl.Styles>
 
-    <!-- Summary tab -->
-    <TabItem Header="Summary">
-      <ScrollViewer>
-        <StackPanel Margin="8" Spacing="4">
-          <TextBlock><Run Text="Run: "/><Run Text="{Binding RunNo}" FontWeight="Bold"/></TextBlock>
-          <TextBlock><Run Text="Method: "/><Run Text="{Binding Method}"/></TextBlock>
-          <TextBlock><Run Text="OFV: "/><Run Text="{Binding Ofv}"/></TextBlock>
-          <TextBlock IsVisible="{Binding ConditionNumber, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
-            <Run Text="Condition number: "/><Run Text="{Binding ConditionNumber}"/>
-          </TextBlock>
-          <TextBlock IsVisible="{Binding ObsRecs, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
-            <Run Text="Observations: "/><Run Text="{Binding ObsRecs}"/>
-            <Run Text="  Individuals: "/><Run Text="{Binding Individuals}"/>
-          </TextBlock>
-          <ItemsControl IsVisible="{Binding HasWarnings}" ItemsSource="{Binding Warnings}">
-            <ItemsControl.ItemTemplate>
-              <DataTemplate>
-                <TextBlock Text="{Binding}" Foreground="OrangeRed" FontStyle="Italic" />
-              </DataTemplate>
-            </ItemsControl.ItemTemplate>
-          </ItemsControl>
-        </StackPanel>
-      </ScrollViewer>
-    </TabItem>
+  <Grid ColumnDefinitions="2*,4,3*">
 
-    <!-- Parameters tab (all) -->
-    <TabItem Header="Parameters">
-      <DataGrid ItemsSource="{Binding AllParameters}"
+    <!-- Estimation steps (bottom-left) -->
+    <DockPanel Grid.Column="0">
+      <Border Classes="panelHeader" DockPanel.Dock="Top">
+        <TextBlock Text="Estimation" />
+      </Border>
+      <DataGrid ItemsSource="{Binding Estimations}"
+                SelectedItem="{Binding SelectedEstimation}"
                 IsReadOnly="True"
                 GridLinesVisibility="Horizontal"
                 AutoGenerateColumns="False">
         <DataGrid.Columns>
-          <DataGridTextColumn Header="Type"      Binding="{Binding Kind}"     Width="60"  />
-          <DataGridTextColumn Header="No."       Binding="{Binding Index}"    Width="40"  />
-          <DataGridTextColumn Header="Label"     Binding="{Binding Label}"    Width="80"  />
-          <DataGridTextColumn Header="Estimate"  Binding="{Binding Estimate}" Width="100" />
-          <DataGridTextColumn Header="S.E."      Binding="{Binding Se}"       Width="90"  />
-          <DataGridTextColumn Header="%RSE"      Binding="{Binding Rse}"      Width="70"  />
-          <DataGridTextColumn Header="95% CI"    Binding="{Binding Ci}"       Width="160" />
-          <DataGridTextColumn Header="Shrinkage" Binding="{Binding Shrinkage}" Width="90" />
+          <DataGridTextColumn Header="Step"   Binding="{Binding Step}"            Width="50"  />
+          <DataGridTextColumn Header="Title"  Binding="{Binding Title}"           Width="*"   />
+          <DataGridTextColumn Header="Status" Binding="{Binding Status}"          Width="100" />
+          <DataGridTextColumn Header="OFV"    Binding="{Binding Ofv}"             Width="100" />
+          <DataGridTextColumn Header="Cond No" Binding="{Binding ConditionNumber}" Width="80" />
         </DataGrid.Columns>
       </DataGrid>
-    </TabItem>
+    </DockPanel>
 
-    <!-- Theta tab -->
-    <TabItem Header="Theta" IsVisible="{Binding HasThetas}">
-      <DataGrid ItemsSource="{Binding Thetas}"
-                IsReadOnly="True"
-                GridLinesVisibility="Horizontal"
-                AutoGenerateColumns="False">
-        <DataGrid.Columns>
-          <DataGridTextColumn Header="&#952;"      Binding="{Binding Index}"    Width="40"  />
-          <DataGridTextColumn Header="Label"    Binding="{Binding Label}"    Width="80"  />
-          <DataGridTextColumn Header="Estimate" Binding="{Binding Estimate}" Width="100" />
-          <DataGridTextColumn Header="S.E."     Binding="{Binding Se}"       Width="90"  />
-          <DataGridTextColumn Header="%RSE"     Binding="{Binding Rse}"      Width="70"  />
-          <DataGridTextColumn Header="95% CI"   Binding="{Binding Ci}"       Width="160" />
-        </DataGrid.Columns>
-      </DataGrid>
-    </TabItem>
+    <GridSplitter Grid.Column="1" ResizeDirection="Columns" Background="#C8C8C8"
+                  VerticalAlignment="Stretch" />
 
-    <!-- Omega tab -->
-    <TabItem Header="Omega" IsVisible="{Binding HasOmegas}">
-      <DataGrid ItemsSource="{Binding Omegas}"
-                IsReadOnly="True"
-                GridLinesVisibility="Horizontal"
-                AutoGenerateColumns="False">
-        <DataGrid.Columns>
-          <DataGridTextColumn Header="&#969;&#178;"   Binding="{Binding Index}"    Width="40"  />
-          <DataGridTextColumn Header="Label"     Binding="{Binding Label}"    Width="80"  />
-          <DataGridTextColumn Header="Estimate"  Binding="{Binding Estimate}" Width="100" />
-          <DataGridTextColumn Header="S.E."      Binding="{Binding Se}"       Width="90"  />
-          <DataGridTextColumn Header="%RSE"      Binding="{Binding Rse}"      Width="70"  />
-          <DataGridTextColumn Header="95% CI"    Binding="{Binding Ci}"       Width="160" />
-          <DataGridTextColumn Header="Shrinkage" Binding="{Binding Shrinkage}" Width="90" />
-        </DataGrid.Columns>
-      </DataGrid>
-    </TabItem>
+    <!-- Parameter tabs (bottom-right) -->
+    <TabControl Grid.Column="2" Padding="0">
 
-    <!-- Sigma tab -->
-    <TabItem Header="Sigma" IsVisible="{Binding HasSigmas}">
-      <DataGrid ItemsSource="{Binding Sigmas}"
-                IsReadOnly="True"
-                GridLinesVisibility="Horizontal"
-                AutoGenerateColumns="False">
-        <DataGrid.Columns>
-          <DataGridTextColumn Header="&#963;&#178;"   Binding="{Binding Index}"    Width="40"  />
-          <DataGridTextColumn Header="Label"     Binding="{Binding Label}"    Width="80"  />
-          <DataGridTextColumn Header="Estimate"  Binding="{Binding Estimate}" Width="100" />
-          <DataGridTextColumn Header="S.E."      Binding="{Binding Se}"       Width="90"  />
-          <DataGridTextColumn Header="%RSE"      Binding="{Binding Rse}"      Width="70"  />
-          <DataGridTextColumn Header="95% CI"    Binding="{Binding Ci}"       Width="160" />
-          <DataGridTextColumn Header="Shrinkage" Binding="{Binding Shrinkage}" Width="90" />
-        </DataGrid.Columns>
-      </DataGrid>
-    </TabItem>
+      <TabItem Header="Theta">
+        <DataGrid ItemsSource="{Binding SelectedEstimation.Thetas}"
+                  IsReadOnly="True" GridLinesVisibility="Horizontal" AutoGenerateColumns="False">
+          <DataGrid.Columns>
+            <DataGridTextColumn Header="Theta"             Binding="{Binding Index}"    Width="60"  />
+            <DataGridTextColumn Header="Label"             Binding="{Binding Label}"    Width="100" />
+            <DataGridTextColumn Header="Estimate"          Binding="{Binding Estimate}" Width="110" />
+            <DataGridTextColumn Header="SE"                Binding="{Binding Se}"       Width="100" />
+            <DataGridTextColumn Header="Rel SE (%)"        Binding="{Binding Rse}"      Width="90"  />
+            <DataGridTextColumn Header="Asymptotic 95% CI" Binding="{Binding Ci}"       Width="*"   />
+          </DataGrid.Columns>
+        </DataGrid>
+      </TabItem>
 
-  </TabControl>
+      <TabItem Header="Omega">
+        <DataGrid ItemsSource="{Binding SelectedEstimation.Omegas}"
+                  IsReadOnly="True" GridLinesVisibility="Horizontal" AutoGenerateColumns="False">
+          <DataGrid.Columns>
+            <DataGridTextColumn Header="Omega"             Binding="{Binding Index}"     Width="60"  />
+            <DataGridTextColumn Header="Label"             Binding="{Binding Label}"     Width="100" />
+            <DataGridTextColumn Header="Estimate"          Binding="{Binding Estimate}"  Width="110" />
+            <DataGridTextColumn Header="SE"                Binding="{Binding Se}"        Width="100" />
+            <DataGridTextColumn Header="Rel SE (%)"        Binding="{Binding Rse}"       Width="90"  />
+            <DataGridTextColumn Header="Shrinkage (%)"     Binding="{Binding Shrinkage}" Width="100" />
+            <DataGridTextColumn Header="Asymptotic 95% CI" Binding="{Binding Ci}"        Width="*"   />
+          </DataGrid.Columns>
+        </DataGrid>
+      </TabItem>
+
+      <TabItem Header="Sigma">
+        <DataGrid ItemsSource="{Binding SelectedEstimation.Sigmas}"
+                  IsReadOnly="True" GridLinesVisibility="Horizontal" AutoGenerateColumns="False">
+          <DataGrid.Columns>
+            <DataGridTextColumn Header="Sigma"             Binding="{Binding Index}"     Width="60"  />
+            <DataGridTextColumn Header="Label"             Binding="{Binding Label}"     Width="100" />
+            <DataGridTextColumn Header="Estimate"          Binding="{Binding Estimate}"  Width="110" />
+            <DataGridTextColumn Header="SE"                Binding="{Binding Se}"        Width="100" />
+            <DataGridTextColumn Header="Rel SE (%)"        Binding="{Binding Rse}"       Width="90"  />
+            <DataGridTextColumn Header="Shrinkage (%)"     Binding="{Binding Shrinkage}" Width="100" />
+            <DataGridTextColumn Header="Asymptotic 95% CI" Binding="{Binding Ci}"        Width="*"   />
+          </DataGrid.Columns>
+        </DataGrid>
+      </TabItem>
+
+      <TabItem Header="Matrices">
+        <TextBlock Margin="12" Foreground="#888"
+                   Text="Variance-covariance and correlation matrices are not yet available." />
+      </TabItem>
+
+      <TabItem Header="Miscellaneous">
+        <ScrollViewer>
+          <Grid Margin="12" ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" >
+            <TextBlock Grid.Row="0" Grid.Column="0" Text="Run"          FontWeight="SemiBold" Margin="0,2" />
+            <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding RunNo}"       Margin="0,2" />
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="Parent"       FontWeight="SemiBold" Margin="0,2" />
+            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding ParentNo}"    Margin="0,2" />
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="Comment"      FontWeight="SemiBold" Margin="0,2" />
+            <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding Comment}"     Margin="0,2" TextWrapping="Wrap" />
+            <TextBlock Grid.Row="3" Grid.Column="0" Text="Obs. records" FontWeight="SemiBold" Margin="0,2" />
+            <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding ObsRecs}"     Margin="0,2" />
+            <TextBlock Grid.Row="4" Grid.Column="0" Text="Individuals"  FontWeight="SemiBold" Margin="0,2" />
+            <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding Individuals}" Margin="0,2" />
+            <TextBlock Grid.Row="5" Grid.Column="0" Text="Files"        FontWeight="SemiBold" Margin="0,2" />
+            <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding FileCount}"   Margin="0,2" />
+          </Grid>
+        </ScrollViewer>
+      </TabItem>
+
+      <TabItem Header="PsN">
+        <TextBlock Margin="12" Foreground="#888"
+                   Text="PsN results are not yet available." />
+      </TabItem>
+
+    </TabControl>
+
+  </Grid>
 
 </UserControl>

--- a/src/Census.App/Views/RunDetailView.axaml
+++ b/src/Census.App/Views/RunDetailView.axaml
@@ -31,11 +31,13 @@
                 GridLinesVisibility="Horizontal"
                 AutoGenerateColumns="False">
         <DataGrid.Columns>
-          <DataGridTextColumn Header="Step"   Binding="{Binding Step}"            Width="50"  />
-          <DataGridTextColumn Header="Title"  Binding="{Binding Title}"           Width="*"   />
-          <DataGridTextColumn Header="Status" Binding="{Binding Status}"          Width="100" />
-          <DataGridTextColumn Header="OFV"    Binding="{Binding Ofv}"             Width="100" />
-          <DataGridTextColumn Header="Cond No" Binding="{Binding ConditionNumber}" Width="80" />
+          <DataGridTextColumn Header="Step"     Binding="{Binding Step}"            Width="44"  />
+          <DataGridTextColumn Header="Title"    Binding="{Binding Title}"           Width="*"   />
+          <DataGridTextColumn Header="Status"   Binding="{Binding Status}"          Width="90"  />
+          <DataGridTextColumn Header="Est Time" Binding="{Binding EstTime}"         Width="80"  />
+          <DataGridTextColumn Header="Cov Time" Binding="{Binding CovTime}"         Width="80"  />
+          <DataGridTextColumn Header="OFV"      Binding="{Binding Ofv}"             Width="90"  />
+          <DataGridTextColumn Header="Cond No"  Binding="{Binding ConditionNumber}" Width="70"  />
         </DataGrid.Columns>
       </DataGrid>
     </DockPanel>

--- a/src/Census.App/Views/RunDetailView.axaml.cs
+++ b/src/Census.App/Views/RunDetailView.axaml.cs
@@ -1,0 +1,8 @@
+using Avalonia.Controls;
+
+namespace Census.App.Views;
+
+public partial class RunDetailView : UserControl
+{
+    public RunDetailView() => InitializeComponent();
+}

--- a/src/Census.App/Views/SettingsWindow.axaml
+++ b/src/Census.App/Views/SettingsWindow.axaml
@@ -1,0 +1,33 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:Census.App.ViewModels"
+        x:Class="Census.App.Views.SettingsWindow"
+        x:DataType="vm:SettingsViewModel"
+        Title="Settings"
+        Width="480" Height="280"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False">
+
+  <DockPanel Margin="12">
+    <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal"
+                HorizontalAlignment="Right" Spacing="8" Margin="0,12,0,0">
+      <Button Content="Save" Command="{Binding SaveCommand}" IsDefault="True" />
+      <Button Content="Close" IsCancel="True" />
+    </StackPanel>
+
+    <Grid RowDefinitions="Auto,Auto,Auto,Auto" ColumnDefinitions="120,*" RowSpacing="8">
+      <TextBlock Grid.Row="0" Grid.Column="0" Text="NONMEM path:" VerticalAlignment="Center"/>
+      <TextBox   Grid.Row="0" Grid.Column="1" Text="{Binding NonmemPath}" />
+
+      <TextBlock Grid.Row="1" Grid.Column="0" Text="PsN path:" VerticalAlignment="Center"/>
+      <TextBox   Grid.Row="1" Grid.Column="1" Text="{Binding PsnPath}" />
+
+      <TextBlock Grid.Row="2" Grid.Column="0" Text="Perl path:" VerticalAlignment="Center"/>
+      <TextBox   Grid.Row="2" Grid.Column="1" Text="{Binding PerlPath}" />
+
+      <TextBlock Grid.Row="3" Grid.Column="0" Text="R path:" VerticalAlignment="Center"/>
+      <TextBox   Grid.Row="3" Grid.Column="1" Text="{Binding RPath}" />
+    </Grid>
+  </DockPanel>
+
+</Window>

--- a/src/Census.App/Views/SettingsWindow.axaml
+++ b/src/Census.App/Views/SettingsWindow.axaml
@@ -4,7 +4,7 @@
         x:Class="Census.App.Views.SettingsWindow"
         x:DataType="vm:SettingsViewModel"
         Title="Settings"
-        Width="480" Height="280"
+        Width="480" Height="320"
         WindowStartupLocation="CenterOwner"
         CanResize="False">
 
@@ -15,7 +15,7 @@
       <Button Content="Close" IsCancel="True" />
     </StackPanel>
 
-    <Grid RowDefinitions="Auto,Auto,Auto,Auto" ColumnDefinitions="120,*" RowSpacing="8">
+    <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto" ColumnDefinitions="120,*" RowSpacing="8">
       <TextBlock Grid.Row="0" Grid.Column="0" Text="NONMEM path:" VerticalAlignment="Center"/>
       <TextBox   Grid.Row="0" Grid.Column="1" Text="{Binding NonmemPath}" />
 
@@ -27,6 +27,11 @@
 
       <TextBlock Grid.Row="3" Grid.Column="0" Text="R path:" VerticalAlignment="Center"/>
       <TextBox   Grid.Row="3" Grid.Column="1" Text="{Binding RPath}" />
+
+      <TextBlock Grid.Row="4" Grid.Column="0" Text="Grid font size:" VerticalAlignment="Center"/>
+      <NumericUpDown Grid.Row="4" Grid.Column="1" HorizontalAlignment="Left" Width="120"
+                     Minimum="8" Maximum="24" Increment="1" FormatString="0"
+                     Value="{Binding GridFontSize}" />
     </Grid>
   </DockPanel>
 

--- a/src/Census.App/Views/SettingsWindow.axaml.cs
+++ b/src/Census.App/Views/SettingsWindow.axaml.cs
@@ -1,0 +1,8 @@
+using Avalonia.Controls;
+
+namespace Census.App.Views;
+
+public partial class SettingsWindow : Window
+{
+    public SettingsWindow() => InitializeComponent();
+}

--- a/src/Census.Archive/RunArchiver.cs
+++ b/src/Census.Archive/RunArchiver.cs
@@ -1,0 +1,106 @@
+using System.IO.Compression;
+using System.Text.Json;
+using Census.Domain;
+
+namespace Census.Archive;
+
+/// <summary>
+/// Creates a ZIP archive containing a run's file artifacts and a JSON manifest.
+/// </summary>
+public sealed class RunArchiver : IRunArchiver
+{
+    /// <inheritdoc />
+    public void Archive(Run run, string destinationZip, bool includeData)
+    {
+        // Delete existing zip so we can use ZipArchiveMode.Create cleanly.
+        if (File.Exists(destinationZip))
+            File.Delete(destinationZip);
+
+        // Track entry names already used so we can de-duplicate.
+        var usedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // Manifest tracks the entries that were actually added.
+        var manifestFiles = new List<ManifestFile>();
+
+        using var archive = new ZipArchive(File.Create(destinationZip), ZipArchiveMode.Create, leaveOpen: false);
+
+        foreach (var artifact in run.Files)
+        {
+            // Skip missing files.
+            if (!File.Exists(artifact.Path))
+                continue;
+
+            // Skip data-role artifacts when includeData is false.
+            if (!includeData && string.Equals(artifact.Role, "data", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var entryName = MakeUniqueEntryName(Path.GetFileName(artifact.Path), usedNames);
+            usedNames.Add(entryName);
+
+            var entry = archive.CreateEntry(entryName, CompressionLevel.Optimal);
+            using (var entryStream = entry.Open())
+            using (var sourceStream = File.OpenRead(artifact.Path))
+            {
+                sourceStream.CopyTo(entryStream);
+            }
+
+            manifestFiles.Add(new ManifestFile(artifact.Role, entryName, artifact.Md5));
+        }
+
+        // Build and write the manifest.
+        var lastEstimation = run.Estimations.Count > 0 ? run.Estimations[^1] : null;
+
+        var manifest = new RunManifest(
+            RunNo: run.RunNo,
+            Method: lastEstimation?.Method,
+            OFV: lastEstimation?.Ofv,
+            Individuals: run.Individuals,
+            ObsRecs: run.ObsRecs,
+            Files: manifestFiles
+        );
+
+        var manifestEntry = archive.CreateEntry("census_manifest.json", CompressionLevel.Optimal);
+        using var manifestStream = manifestEntry.Open();
+        JsonSerializer.Serialize(manifestStream, manifest, ManifestJsonContext.Default.RunManifest);
+    }
+
+    private static string MakeUniqueEntryName(string filename, HashSet<string> usedNames)
+    {
+        if (!usedNames.Contains(filename))
+            return filename;
+
+        var nameWithoutExt = Path.GetFileNameWithoutExtension(filename);
+        var ext = Path.GetExtension(filename);
+        var counter = 2;
+
+        string candidate;
+        do
+        {
+            candidate = $"{nameWithoutExt}_{counter}{ext}";
+            counter++;
+        }
+        while (usedNames.Contains(candidate));
+
+        return candidate;
+    }
+}
+
+// DTO types used only for serialization — kept internal to this file.
+
+internal sealed record ManifestFile(string Role, string Path, string? Md5);
+
+internal sealed record RunManifest(
+    string RunNo,
+    string? Method,
+    double? OFV,
+    int? Individuals,
+    int? ObsRecs,
+    IReadOnlyList<ManifestFile> Files
+);
+
+[System.Text.Json.Serialization.JsonSerializable(typeof(RunManifest))]
+[System.Text.Json.Serialization.JsonSerializable(typeof(ManifestFile))]
+[System.Text.Json.Serialization.JsonSourceGenerationOptions(WriteIndented = true)]
+internal sealed partial class ManifestJsonContext : System.Text.Json.Serialization.JsonSerializerContext
+{
+}

--- a/src/Census.Cli/Commands/Commands.cs
+++ b/src/Census.Cli/Commands/Commands.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using Census.Storage;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -13,6 +14,67 @@ internal static class Stub
     public static int NotImplemented(string command)
     {
         AnsiConsole.MarkupLine($"[yellow]'{command}' is scaffolded but not yet implemented.[/]");
+        return 0;
+    }
+}
+
+internal sealed class NewCommand : Command<NewCommand.Settings>
+{
+    public sealed class Settings : CommandSettings
+    {
+        [CommandArgument(0, "<project>")]
+        [Description("Path to the .cen project file to create.")]
+        public string Project { get; init; } = string.Empty;
+    }
+
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellation)
+    {
+        new SqliteProjectStore().Create(settings.Project);
+        AnsiConsole.MarkupLine($"[green]Created[/] {settings.Project}");
+        return 0;
+    }
+}
+
+internal sealed class ListCommand : Command<ListCommand.Settings>
+{
+    public sealed class Settings : CommandSettings
+    {
+        [CommandArgument(0, "<project>")]
+        [Description("Path to the .cen project file.")]
+        public string Project { get; init; } = string.Empty;
+    }
+
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellation)
+    {
+        var store = new SqliteProjectStore();
+        store.Open(settings.Project);
+        var runs = store.GetRuns();
+
+        if (runs.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[grey]No runs in project.[/]");
+            return 0;
+        }
+
+        var table = new Table().Border(TableBorder.Rounded);
+        table.AddColumn("Run");
+        table.AddColumn("Parent");
+        table.AddColumn("Method");
+        table.AddColumn("OFV");
+        table.AddColumn("Key");
+
+        foreach (var run in runs)
+        {
+            var first = run.Estimations.Count > 0 ? run.Estimations[^1] : null;
+            table.AddRow(
+                run.RunNo,
+                run.ParentNo ?? string.Empty,
+                first?.Method ?? string.Empty,
+                first?.Ofv?.ToString("0.000", System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty,
+                run.KeyRun ? "[green]✓[/]" : string.Empty);
+        }
+
+        AnsiConsole.Write(table);
         return 0;
     }
 }

--- a/src/Census.Cli/Commands/Commands.cs
+++ b/src/Census.Cli/Commands/Commands.cs
@@ -1,22 +1,13 @@
 using System.ComponentModel;
+using System.Text;
+using Census.Archive;
+using Census.Import;
+using Census.Reports;
 using Census.Storage;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
 namespace Census.Cli.Commands;
-
-/// <summary>
-/// Command stubs that define the headless CLI surface (IMPLEMENTATION_PLAN.md, phase 5).
-/// Each will delegate to the shared Census.* services as those phases land.
-/// </summary>
-internal static class Stub
-{
-    public static int NotImplemented(string command)
-    {
-        AnsiConsole.MarkupLine($"[yellow]'{command}' is scaffolded but not yet implemented.[/]");
-        return 0;
-    }
-}
 
 internal sealed class NewCommand : Command<NewCommand.Settings>
 {
@@ -92,8 +83,40 @@ internal sealed class ImportCommand : Command<ImportCommand.Settings>
         public string Project { get; init; } = string.Empty;
     }
 
-    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellation) =>
-        Stub.NotImplemented("import");
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellation)
+    {
+        if (!File.Exists(settings.Source))
+        {
+            AnsiConsole.MarkupLine($"[red]Source file not found: {settings.Source}[/]");
+            return 1;
+        }
+
+        var importer = new NonmemXmlImporter();
+        if (!importer.CanImport(settings.Source))
+        {
+            AnsiConsole.MarkupLine($"[red]Cannot import file (unrecognised format): {settings.Source}[/]");
+            return 1;
+        }
+
+        try
+        {
+            var store = new SqliteProjectStore();
+            if (File.Exists(settings.Project))
+                store.Open(settings.Project);
+            else
+                store.Create(settings.Project);
+
+            var run = importer.Import(settings.Source);
+            store.SaveRun(run);
+            AnsiConsole.MarkupLine($"[green]Imported[/] run [bold]{run.RunNo}[/] from {settings.Source}");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.MarkupLine($"[red]Import failed: {ex.Message}[/]");
+            return 1;
+        }
+    }
 }
 
 internal sealed class ImportFolderCommand : Command<ImportFolderCommand.Settings>
@@ -101,31 +124,135 @@ internal sealed class ImportFolderCommand : Command<ImportFolderCommand.Settings
     public sealed class Settings : CommandSettings
     {
         [CommandArgument(0, "<folder>")]
+        [Description("Directory to scan for NONMEM XML files.")]
         public string Folder { get; init; } = string.Empty;
 
         [CommandArgument(1, "<project>")]
+        [Description("Target .cen project file.")]
         public string Project { get; init; } = string.Empty;
     }
 
-    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellation) =>
-        Stub.NotImplemented("import-folder");
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellation)
+    {
+        if (!Directory.Exists(settings.Folder))
+        {
+            AnsiConsole.MarkupLine($"[red]Folder not found: {settings.Folder}[/]");
+            return 1;
+        }
+
+        var store = new SqliteProjectStore();
+        if (File.Exists(settings.Project))
+            store.Open(settings.Project);
+        else
+            store.Create(settings.Project);
+
+        var files = Directory.GetFiles(settings.Folder, "*.xml", SearchOption.AllDirectories);
+
+        var imported = 0;
+        var skipped = 0;
+        var failed = 0;
+
+        AnsiConsole.Progress()
+            .AutoClear(false)
+            .Columns(new TaskDescriptionColumn(), new ProgressBarColumn(), new PercentageColumn(), new SpinnerColumn())
+            .Start(ctx =>
+            {
+                var task = ctx.AddTask("[green]Importing[/]", maxValue: files.Length);
+                foreach (var file in files)
+                {
+                    var imp = new NonmemXmlImporter();
+                    if (!imp.CanImport(file))
+                    {
+                        skipped++;
+                        task.Increment(1);
+                        continue;
+                    }
+
+                    try
+                    {
+                        var run = imp.Import(file);
+                        store.SaveRun(run);
+                        imported++;
+                    }
+                    catch
+                    {
+                        failed++;
+                    }
+
+                    task.Increment(1);
+                }
+            });
+
+        var summary = new Table().Border(TableBorder.Rounded);
+        summary.AddColumn("Result");
+        summary.AddColumn("Count");
+        summary.AddRow("[green]Imported[/]", imported.ToString());
+        summary.AddRow("[grey]Skipped[/]", skipped.ToString());
+        summary.AddRow("[red]Failed[/]", failed.ToString());
+        AnsiConsole.Write(summary);
+
+        return 0;
+    }
 }
 
 internal sealed class ExportRunCommand : Command<ExportRunCommand.Settings>
 {
     public sealed class Settings : CommandSettings
     {
-        [CommandArgument(0, "<runno>")]
+        [CommandArgument(0, "<project>")]
+        [Description("Path to the .cen project file.")]
+        public string Project { get; init; } = string.Empty;
+
+        [CommandArgument(1, "<runno>")]
+        [Description("Run number to export.")]
         public string RunNo { get; init; } = string.Empty;
 
         [CommandOption("-f|--format <FORMAT>")]
-        [Description("csv | html | latex")]
+        [Description("Output format: csv, html, latex. Default: html.")]
         [DefaultValue("html")]
         public string Format { get; init; } = "html";
+
+        [CommandOption("-o|--output <FILE>")]
+        [Description("Output file path. Writes to stdout if omitted.")]
+        public string? Output { get; init; }
     }
 
-    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellation) =>
-        Stub.NotImplemented("export-run");
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellation)
+    {
+        var store = new SqliteProjectStore();
+        store.Open(settings.Project);
+        var runs = store.GetRuns();
+
+        var run = runs.FirstOrDefault(r =>
+            string.Equals(r.RunNo, settings.RunNo, StringComparison.OrdinalIgnoreCase));
+
+        if (run is null)
+        {
+            AnsiConsole.MarkupLine($"[red]Run not found: {settings.RunNo}[/]");
+            return 1;
+        }
+
+        IReportWriter writer = settings.Format.ToLowerInvariant() switch
+        {
+            "csv" => new CsvReportWriter(),
+            "latex" => new LatexReportWriter(),
+            _ => new HtmlReportWriter(),
+        };
+
+        var content = writer.Render(run);
+
+        if (settings.Output is not null)
+        {
+            File.WriteAllText(settings.Output, content, Encoding.UTF8);
+            AnsiConsole.MarkupLine($"[green]Exported[/] to {settings.Output}");
+        }
+        else
+        {
+            Console.Write(content);
+        }
+
+        return 0;
+    }
 }
 
 internal sealed class CompareCommand : Command<CompareCommand.Settings>
@@ -133,24 +260,108 @@ internal sealed class CompareCommand : Command<CompareCommand.Settings>
     public sealed class Settings : CommandSettings
     {
         [CommandArgument(0, "<project>")]
+        [Description("Path to the .cen project file.")]
         public string Project { get; init; } = string.Empty;
     }
 
-    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellation) =>
-        Stub.NotImplemented("compare");
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellation)
+    {
+        var store = new SqliteProjectStore();
+        store.Open(settings.Project);
+        var runs = store.GetRuns();
+
+        var lookup = runs.ToDictionary(r => r.RunNo, StringComparer.OrdinalIgnoreCase);
+
+        var table = new Table().Border(TableBorder.Rounded);
+        table.AddColumn("Run");
+        table.AddColumn("Parent");
+        table.AddColumn("Method");
+        table.AddColumn("OFV");
+        table.AddColumn("dOFV");
+        table.AddColumn("Cond#");
+        table.AddColumn("Obs");
+        table.AddColumn("Ind");
+        table.AddColumn("Warnings");
+
+        foreach (var run in runs.OrderBy(r => r.IRunNo))
+        {
+            var lastEst = run.Estimations.Count > 0 ? run.Estimations[^1] : null;
+
+            double? dofv = null;
+            if (run.ParentNo is not null
+                && lookup.TryGetValue(run.ParentNo, out var parent)
+                && run.Estimations.Count > 0
+                && parent.Estimations.Count > 0)
+            {
+                dofv = run.Estimations[^1].Ofv - parent.Estimations[^1].Ofv;
+            }
+
+            var dofvStr = dofv switch
+            {
+                null => "",
+                > 0 => $"[red]+{dofv:0.3}[/]",
+                < 0 => $"[green]{dofv:0.3}[/]",
+                _ => "0.000",
+            };
+
+            var warningCount = run.Estimations.Sum(e => e.Warnings.Count);
+            var warningsStr = warningCount > 0 ? warningCount.ToString() : "";
+
+            table.AddRow(
+                run.RunNo,
+                run.ParentNo ?? "",
+                lastEst?.Method ?? "",
+                lastEst?.Ofv?.ToString("0.3", System.Globalization.CultureInfo.InvariantCulture) ?? "",
+                dofvStr,
+                lastEst?.ConditionNumber?.ToString("0", System.Globalization.CultureInfo.InvariantCulture) ?? "",
+                run.ObsRecs?.ToString() ?? "",
+                run.Individuals?.ToString() ?? "",
+                warningsStr);
+        }
+
+        AnsiConsole.Write(table);
+        return 0;
+    }
 }
 
 internal sealed class ArchiveCommand : Command<ArchiveCommand.Settings>
 {
     public sealed class Settings : CommandSettings
     {
-        [CommandArgument(0, "<runno>")]
+        [CommandArgument(0, "<project>")]
+        [Description("Path to the .cen project file.")]
+        public string Project { get; init; } = string.Empty;
+
+        [CommandArgument(1, "<runno>")]
+        [Description("Run number to archive.")]
         public string RunNo { get; init; } = string.Empty;
 
+        [CommandArgument(2, "<destination>")]
+        [Description("Destination ZIP file path.")]
+        public string Destination { get; init; } = string.Empty;
+
         [CommandOption("--include-data")]
+        [Description("Include data-role artifacts in the archive.")]
         public bool IncludeData { get; init; }
     }
 
-    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellation) =>
-        Stub.NotImplemented("archive");
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellation)
+    {
+        var store = new SqliteProjectStore();
+        store.Open(settings.Project);
+        var runs = store.GetRuns();
+
+        var run = runs.FirstOrDefault(r =>
+            string.Equals(r.RunNo, settings.RunNo, StringComparison.OrdinalIgnoreCase));
+
+        if (run is null)
+        {
+            AnsiConsole.MarkupLine($"[red]Run not found: {settings.RunNo}[/]");
+            return 1;
+        }
+
+        new RunArchiver().Archive(run, settings.Destination, settings.IncludeData);
+        AnsiConsole.MarkupLine($"[green]Archived[/] run {run.RunNo} to {settings.Destination}");
+        return 0;
+    }
 }

--- a/src/Census.Cli/Program.cs
+++ b/src/Census.Cli/Program.cs
@@ -14,7 +14,7 @@ app.Configure(config =>
     config.AddCommand<ImportFolderCommand>("import-folder")
         .WithDescription("Discover and import all runs under a folder.");
     config.AddCommand<ExportRunCommand>("export-run")
-        .WithDescription("Export a run report (csv, html, latex).");
+        .WithDescription("Export a run report (default: html; also csv, latex).");
     config.AddCommand<CompareCommand>("compare")
         .WithDescription("Compare runs in a project.");
     config.AddCommand<ArchiveCommand>("archive")

--- a/src/Census.Cli/Program.cs
+++ b/src/Census.Cli/Program.cs
@@ -5,6 +5,10 @@ var app = new CommandApp();
 app.Configure(config =>
 {
     config.SetApplicationName("census");
+    config.AddCommand<NewCommand>("new")
+        .WithDescription("Create a new empty project file.");
+    config.AddCommand<ListCommand>("list")
+        .WithDescription("List the runs in a project.");
     config.AddCommand<ImportCommand>("import")
         .WithDescription("Import a NONMEM run (XML or listing) into a project.");
     config.AddCommand<ImportFolderCommand>("import-folder")

--- a/src/Census.Domain/Run.cs
+++ b/src/Census.Domain/Run.cs
@@ -2,7 +2,7 @@ namespace Census.Domain;
 
 /// <summary>
 /// A single NONMEM run as tracked by Census. This is the behavioral center of the
-/// application; values here are what the importers populate and the reports read.
+/// application: importers populate it and reports read from it.
 /// </summary>
 public sealed record Run
 {
@@ -15,24 +15,80 @@ public sealed record Run
     /// <summary>Parent run number, if this run was derived from another.</summary>
     public string? ParentNo { get; init; }
 
-    /// <summary>Objective function value.</summary>
-    public double? Ofv { get; init; }
-
     /// <summary>User comment.</summary>
     public string? Comment { get; init; }
 
     /// <summary>Whether the user flagged this as a key run.</summary>
     public bool KeyRun { get; init; }
 
-    public IReadOnlyList<Parameter> Thetas { get; init; } = [];
-    public IReadOnlyList<Parameter> Omegas { get; init; } = [];
-    public IReadOnlyList<Parameter> Sigmas { get; init; } = [];
+    /// <summary>Number of observation records in the dataset.</summary>
+    public int? ObsRecs { get; init; }
+
+    /// <summary>Number of individuals in the dataset.</summary>
+    public int? Individuals { get; init; }
+
+    /// <summary>Estimation steps in this run (NONMEM may run several methods).</summary>
+    public IReadOnlyList<Estimation> Estimations { get; init; } = [];
+
+    /// <summary>Files associated with the run (model, control stream, output, tables…).</summary>
+    public IReadOnlyList<FileArtifact> Files { get; init; } = [];
 }
 
-/// <summary>An estimated parameter (theta/omega/sigma) with optional standard error.</summary>
+/// <summary>One estimation step (method) within a run.</summary>
+public sealed record Estimation
+{
+    /// <summary>1-based position of this estimation within the run.</summary>
+    public int Number { get; init; }
+
+    /// <summary>Estimation method (e.g. "FOCEI", "IMP", "SAEM").</summary>
+    public string? Method { get; init; }
+
+    /// <summary>Objective function value.</summary>
+    public double? Ofv { get; init; }
+
+    /// <summary>Change in OFV relative to the parent run, if computed.</summary>
+    public double? DOfv { get; init; }
+
+    /// <summary>Condition number of the covariance step, if available.</summary>
+    public double? ConditionNumber { get; init; }
+
+    public IReadOnlyList<Parameter> Parameters { get; init; } = [];
+
+    public IReadOnlyList<string> Warnings { get; init; } = [];
+}
+
+public enum ParameterKind
+{
+    Theta,
+    Omega,
+    Sigma,
+}
+
+/// <summary>An estimated parameter (theta/omega/sigma) for a given estimation.</summary>
 public sealed record Parameter
 {
-    public required string Label { get; init; }
-    public double Estimate { get; init; }
+    public ParameterKind Kind { get; init; }
+
+    /// <summary>1-based index within its kind (THETA 1, OMEGA 1, …).</summary>
+    public int Index { get; init; }
+
+    public string? Label { get; init; }
+
+    public double? Estimate { get; init; }
+
     public double? StandardError { get; init; }
+
+    /// <summary>Eta/epsilon shrinkage, for omegas/sigmas.</summary>
+    public double? Shrinkage { get; init; }
+}
+
+/// <summary>A file associated with a run, with an optional content hash.</summary>
+public sealed record FileArtifact
+{
+    /// <summary>Logical role: model, ctl, data, output, ext, cov, sdtab, patab…</summary>
+    public required string Role { get; init; }
+
+    public required string Path { get; init; }
+
+    public string? Md5 { get; init; }
 }

--- a/src/Census.Domain/Run.cs
+++ b/src/Census.Domain/Run.cs
@@ -27,6 +27,21 @@ public sealed record Run
     /// <summary>Number of individuals in the dataset.</summary>
     public int? Individuals { get; init; }
 
+    /// <summary>Run start timestamp (NONMEM <c>start_datetime</c>), as reported in the output.</summary>
+    public string? StartDateTime { get; init; }
+
+    /// <summary>Run stop timestamp (NONMEM <c>stop_datetime</c>), as reported in the output.</summary>
+    public string? StopDateTime { get; init; }
+
+    /// <summary>Total CPU time in seconds (NONMEM <c>total_cputime</c>).</summary>
+    public double? TotalCpuTime { get; init; }
+
+    /// <summary>Post-processing elapsed time in seconds (NONMEM <c>post_elapsed_time</c>).</summary>
+    public double? PostElapsedTime { get; init; }
+
+    /// <summary>Final-output elapsed time in seconds (NONMEM <c>finaloutput_elapsed_time</c>).</summary>
+    public double? FinalOutputElapsedTime { get; init; }
+
     /// <summary>Estimation steps in this run (NONMEM may run several methods).</summary>
     public IReadOnlyList<Estimation> Estimations { get; init; } = [];
 
@@ -51,6 +66,12 @@ public sealed record Estimation
 
     /// <summary>Condition number of the covariance step, if available.</summary>
     public double? ConditionNumber { get; init; }
+
+    /// <summary>Estimation elapsed time in seconds (NONMEM <c>estimation_elapsed_time</c>).</summary>
+    public double? EstimationTime { get; init; }
+
+    /// <summary>Covariance-step elapsed time in seconds (NONMEM <c>covariance_elapsed_time</c>).</summary>
+    public double? CovarianceTime { get; init; }
 
     public IReadOnlyList<Parameter> Parameters { get; init; } = [];
 

--- a/src/Census.ExternalTools/ProcessRunner.cs
+++ b/src/Census.ExternalTools/ProcessRunner.cs
@@ -1,0 +1,28 @@
+using System.Diagnostics;
+
+namespace Census.ExternalTools;
+
+/// <summary>
+/// Launches external tools via <see cref="System.Diagnostics.Process"/>.
+/// </summary>
+public sealed class ProcessRunner : IExternalToolRunner
+{
+    /// <inheritdoc/>
+    public int Run(string executable, IReadOnlyList<string> arguments, string? workingDirectory = null)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = executable,
+            Arguments = string.Join(" ", arguments.Select(a => a.Contains(' ') ? $"\"{a}\"" : a)),
+            WorkingDirectory = workingDirectory ?? Directory.GetCurrentDirectory(),
+            UseShellExecute = false,
+            RedirectStandardOutput = false,
+            RedirectStandardError = false,
+            CreateNoWindow = false,
+        };
+
+        var process = Process.Start(startInfo)!;
+        process.WaitForExit();
+        return process.ExitCode;
+    }
+}

--- a/src/Census.Import/NonmemXmlImporter.cs
+++ b/src/Census.Import/NonmemXmlImporter.cs
@@ -88,7 +88,13 @@ public sealed class NonmemXmlImporter : IRunImporter
             var number = ParseInt(Attr(estEl, "number")) ?? 0;
             var method = El(estEl, "estimation_method")?.Value?.Trim();
             var ofv = ParseDouble(El(estEl, "final_objective_function")?.Value);
-            var conditionNumber = ParseConditionNumber(El(estEl, "covariance_status"));
+            // Condition number = ratio of largest to smallest eigenvalue of the correlation
+            // matrix. Prefer an explicit <eigenvalues> vector or populated covariance_status;
+            // otherwise compute it from the <correlation> matrix (NM 7.3 leaves the others empty).
+            var conditionNumber =
+                ConditionNumberFromEigenvalues(El(estEl, "eigenvalues"))
+                ?? ConditionNumberFromCovarianceStatus(El(estEl, "covariance_status"))
+                ?? ConditionNumberFromCorrelation(El(estEl, "correlation"));
             var estimationTime = ParseDouble(El(estEl, "estimation_elapsed_time")?.Value);
             var covarianceTime = ParseDouble(El(estEl, "covariance_elapsed_time")?.Value);
 
@@ -201,7 +207,33 @@ public sealed class NonmemXmlImporter : IRunImporter
         return rows.Select(r => ParseDouble(Els(r, "col").FirstOrDefault()?.Value)).ToList();
     }
 
-    private static double? ParseConditionNumber(XElement? covStatusEl)
+    // Condition number from an explicit <eigenvalues> vector (eigenvalues of the correlation matrix).
+    private static double? ConditionNumberFromEigenvalues(XElement? eigEl)
+    {
+        if (eigEl is null)
+        {
+            return null;
+        }
+
+        var vals = Els(eigEl, "val")
+            .Select(v => ParseDouble(v.Value))
+            .Where(d => d.HasValue)
+            .Select(d => d!.Value)
+            .ToList();
+
+        if (vals.Count == 0)
+        {
+            return null;
+        }
+
+        var min = vals.Min();
+        var max = vals.Max();
+        return min > 0 ? max / min : null;
+    }
+
+    // Condition number from covariance_status eigenvalue attributes, when populated and positive.
+    // Some NONMEM versions leave these zero (or negative for non-positive-definite matrices).
+    private static double? ConditionNumberFromCovarianceStatus(XElement? covStatusEl)
     {
         if (covStatusEl is null)
         {
@@ -211,12 +243,126 @@ public sealed class NonmemXmlImporter : IRunImporter
         var minVal = ParseDouble(Attr(covStatusEl, "mineigenvalue"));
         var maxVal = ParseDouble(Attr(covStatusEl, "maxeigenvalue"));
 
-        if (minVal is null || maxVal is null || minVal == 0.0)
+        if (minVal is null || maxVal is null || minVal.Value <= 0.0 || maxVal.Value <= 0.0)
         {
             return null;
         }
 
-        return maxVal / minVal;
+        return maxVal.Value / minVal.Value;
+    }
+
+    // Condition number computed from the <correlation> matrix. NONMEM stores standard errors on
+    // the diagonal and correlation coefficients off-diagonal; the condition number is the ratio of
+    // the largest to smallest eigenvalue of the correlation matrix (unit diagonal). Parameters with
+    // no standard error (fixed) are excluded, matching NONMEM.
+    private static double? ConditionNumberFromCorrelation(XElement? corrEl)
+    {
+        if (corrEl is null)
+        {
+            return null;
+        }
+
+        var rows = Els(corrEl, "row").ToList();
+        var n = rows.Count;
+        if (n == 0)
+        {
+            return null;
+        }
+
+        var cells = rows.Select(r => Els(r, "col").Select(c => ParseDouble(c.Value)).ToList()).ToList();
+
+        // Active parameters have a non-zero standard error on the diagonal.
+        var active = Enumerable.Range(0, n)
+            .Where(i => i < cells[i].Count && (cells[i][i] ?? 0.0) != 0.0)
+            .ToArray();
+
+        var m = active.Length;
+        if (m == 0)
+        {
+            return null;
+        }
+
+        var r = new double[m, m];
+        for (var a = 0; a < m; a++)
+        {
+            r[a, a] = 1.0;
+            var i = active[a];
+            for (var b = 0; b < a; b++)
+            {
+                var j = active[b];
+                var v = j < cells[i].Count ? cells[i][j] ?? 0.0 : 0.0;
+                r[a, b] = v;
+                r[b, a] = v;
+            }
+        }
+
+        var eig = SymmetricEigenvalues(r, m);
+        var min = eig.Min();
+        var max = eig.Max();
+        return min > 0 ? max / min : null;
+    }
+
+    // Eigenvalues of a symmetric matrix via the cyclic Jacobi rotation method.
+    private static double[] SymmetricEigenvalues(double[,] a, int n)
+    {
+        for (var sweep = 0; sweep < 100; sweep++)
+        {
+            var off = 0.0;
+            for (var p = 0; p < n; p++)
+            {
+                for (var q = p + 1; q < n; q++)
+                {
+                    off += a[p, q] * a[p, q];
+                }
+            }
+
+            if (off < 1e-20)
+            {
+                break;
+            }
+
+            for (var p = 0; p < n; p++)
+            {
+                for (var q = p + 1; q < n; q++)
+                {
+                    if (Math.Abs(a[p, q]) < 1e-300)
+                    {
+                        continue;
+                    }
+
+                    var theta = (a[q, q] - a[p, p]) / (2.0 * a[p, q]);
+                    var t = theta == 0.0
+                        ? 1.0
+                        : Math.Sign(theta) / (Math.Abs(theta) + Math.Sqrt(theta * theta + 1.0));
+                    var c = 1.0 / Math.Sqrt(t * t + 1.0);
+                    var s = t * c;
+
+                    for (var k = 0; k < n; k++)
+                    {
+                        var akp = a[k, p];
+                        var akq = a[k, q];
+                        a[k, p] = c * akp - s * akq;
+                        a[k, q] = s * akp + c * akq;
+                    }
+
+                    for (var k = 0; k < n; k++)
+                    {
+                        var apk = a[p, k];
+                        var aqk = a[q, k];
+                        a[p, k] = c * apk - s * aqk;
+                        a[q, k] = s * apk + c * aqk;
+                    }
+                }
+            }
+        }
+
+        var eigenvalues = new double[n];
+        for (var i = 0; i < n; i++)
+        {
+            eigenvalues[i] = a[i, i];
+        }
+
+        return eigenvalues;
     }
 
     private static List<string> ParseWarnings(XElement? statusEl, XElement? infoEl)

--- a/src/Census.Import/NonmemXmlImporter.cs
+++ b/src/Census.Import/NonmemXmlImporter.cs
@@ -136,7 +136,7 @@ public sealed class NonmemXmlImporter : IRunImporter
         // Lower-triangular matrix: row i has i cols; diagonal = last col of each row.
         var rows = Els(matEl, "row").ToList();
         var seRows = seEl is not null ? Els(seEl, "row").ToList() : [];
-        var shrinkRows = shrinkEl is not null ? Els(shrinkEl, "row").ToList() : [];
+        var shrinkValues = FlattenShrinkageValues(shrinkEl);
 
         var result = new List<Parameter>(rows.Count);
         for (var i = 0; i < rows.Count; i++)
@@ -144,10 +144,6 @@ public sealed class NonmemXmlImporter : IRunImporter
             var diagonalCol = Els(rows[i], "col").LastOrDefault();
             var diagonalSe = i < seRows.Count
                 ? Els(seRows[i], "col").LastOrDefault()
-                : null;
-            // Shrinkage tables have one value per row (one per eta/eps).
-            var shrinkCol = i < shrinkRows.Count
-                ? Els(shrinkRows[i], "col").FirstOrDefault()
                 : null;
 
             result.Add(new Parameter
@@ -157,11 +153,28 @@ public sealed class NonmemXmlImporter : IRunImporter
                 Label = Attr(rows[i], "rname")?.Trim(),
                 Estimate = diagonalCol is not null ? ParseDouble(diagonalCol.Value) : null,
                 StandardError = diagonalSe is not null ? ParseDouble(diagonalSe.Value) : null,
-                Shrinkage = shrinkCol is not null ? ParseDouble(shrinkCol.Value) : null,
+                Shrinkage = i < shrinkValues.Count ? shrinkValues[i] : null,
             });
         }
 
         return result;
+    }
+
+    // Shrinkage tables come in two layouts:
+    //   Flat (7.3–7.5): one row per subpopulation, one col per eta/eps.
+    //   Per-parameter (fixture / 7.6+): one row per eta/eps, one col per row.
+    // Both produce the same indexed list of values.
+    private static List<double?> FlattenShrinkageValues(XElement? shrinkEl)
+    {
+        if (shrinkEl is null) return [];
+        var rows = Els(shrinkEl, "row").ToList();
+        if (rows.Count == 0) return [];
+
+        var firstRowCols = Els(rows[0], "col").ToList();
+        if (rows.Count == 1 && firstRowCols.Count > 1)
+            return firstRowCols.Select(c => ParseDouble(c.Value)).ToList();
+
+        return rows.Select(r => ParseDouble(Els(r, "col").FirstOrDefault()?.Value)).ToList();
     }
 
     private static double? ParseConditionNumber(XElement? covStatusEl)

--- a/src/Census.Import/NonmemXmlImporter.cs
+++ b/src/Census.Import/NonmemXmlImporter.cs
@@ -1,17 +1,258 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Xml.Linq;
 using Census.Domain;
 
 namespace Census.Import;
 
 /// <summary>
-/// Imports NONMEM 7.2+ XML output. The modern import path and the first to be implemented.
-/// Replaces the generated <c>nmoutput.pas</c> bindings with schema-aware traversal into
-/// typed domain objects.
+/// Imports NONMEM 7.2+ XML output files into <see cref="Run"/> domain objects.
+/// Parses by local element/attribute name so it is robust to the nm: namespace prefix
+/// used in real NONMEM 7.3+ output and to bare-name older output.
 /// </summary>
 public sealed class NonmemXmlImporter : IRunImporter
 {
     public bool CanImport(string sourcePath) =>
         sourcePath.EndsWith(".xml", StringComparison.OrdinalIgnoreCase);
 
-    public Run Import(string sourcePath) =>
-        throw new NotImplementedException("NONMEM XML import — phase 3.");
+    public Run Import(string sourcePath)
+    {
+        var xml = File.ReadAllText(sourcePath);
+        var run = ImportXml(xml, sourcePath);
+        var md5 = ComputeMd5(sourcePath);
+        return run with
+        {
+            Files = [new FileArtifact { Role = "output", Path = sourcePath, Md5 = md5 }],
+        };
+    }
+
+    /// <summary>Parse from an XML string. Exposed for testing without disk I/O.</summary>
+    public Run ImportXml(string xml, string sourcePath)
+    {
+        var doc = XDocument.Parse(xml);
+        var root = doc.Root!;
+
+        var nonmem = El(root, "nonmem");
+        var firstProblem = nonmem is not null ? El(nonmem, "problem") : null;
+
+        var obsRecs = ParseInt(Attr(El(firstProblem, "problem_options"), "data_nobs"));
+        var individuals = ParseInt(Attr(El(firstProblem, "problem_options"), "data_nind"));
+
+        var estimations = firstProblem is not null
+            ? ParseEstimations(firstProblem)
+            : [];
+
+        var runNo = DeriveRunNo(sourcePath);
+
+        return new Run
+        {
+            RunNo = runNo,
+            IRunNo = int.TryParse(runNo, NumberStyles.Integer, CultureInfo.InvariantCulture, out var n) ? n : 0,
+            ObsRecs = obsRecs,
+            Individuals = individuals,
+            Estimations = estimations,
+            Files = [],
+        };
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static List<Estimation> ParseEstimations(XElement problem)
+    {
+        var result = new List<Estimation>();
+
+        // Both "estimation" and "sir_estimation" (NONMEM 7.6+) follow the same sub-structure.
+        foreach (var estEl in problem.Elements()
+            .Where(e => e.Name.LocalName is "estimation" or "sir_estimation"))
+        {
+            var number = ParseInt(Attr(estEl, "number")) ?? 0;
+            var method = El(estEl, "estimation_method")?.Value?.Trim();
+            var ofv = ParseDouble(El(estEl, "final_objective_function")?.Value);
+            var conditionNumber = ParseConditionNumber(El(estEl, "covariance_status"));
+
+            // Shrinkage: prefer etashrinksd (7.3+, SD-based) over etashrink (7.2 legacy).
+            var etaShrinkEl = El(estEl, "etashrinksd") ?? El(estEl, "etashrink");
+            var epsShrinkEl = El(estEl, "epsshrinksd") ?? El(estEl, "epsshrink");
+
+            var thetas = ParseThetas(El(estEl, "theta"), El(estEl, "thetase"));
+            var omegas = ParseMatrix(ParameterKind.Omega, El(estEl, "omega"), El(estEl, "omegase"), etaShrinkEl);
+            var sigmas = ParseMatrix(ParameterKind.Sigma, El(estEl, "sigma"), El(estEl, "sigmase"), epsShrinkEl);
+
+            var warnings = ParseWarnings(
+                El(estEl, "termination_status"),
+                El(estEl, "termination_information"));
+
+            result.Add(new Estimation
+            {
+                Number = number,
+                Method = method,
+                Ofv = ofv,
+                ConditionNumber = conditionNumber,
+                Parameters = [.. thetas, .. omegas, .. sigmas],
+                Warnings = warnings,
+            });
+        }
+
+        return result;
+    }
+
+    private static List<Parameter> ParseThetas(XElement? thetaEl, XElement? thetaseEl)
+    {
+        if (thetaEl is null)
+        {
+            return [];
+        }
+
+        var estimates = Els(thetaEl, "val").ToList();
+        var ses = thetaseEl is not null ? Els(thetaseEl, "val").ToList() : [];
+
+        var result = new List<Parameter>(estimates.Count);
+        for (var i = 0; i < estimates.Count; i++)
+        {
+            result.Add(new Parameter
+            {
+                Kind = ParameterKind.Theta,
+                Index = i + 1,
+                Label = Attr(estimates[i], "name")?.Trim(),
+                Estimate = ParseDouble(estimates[i].Value),
+                StandardError = i < ses.Count ? ParseDouble(ses[i].Value) : null,
+            });
+        }
+
+        return result;
+    }
+
+    private static List<Parameter> ParseMatrix(
+        ParameterKind kind,
+        XElement? matEl,
+        XElement? seEl,
+        XElement? shrinkEl)
+    {
+        if (matEl is null)
+        {
+            return [];
+        }
+
+        // Lower-triangular matrix: row i has i cols; diagonal = last col of each row.
+        var rows = Els(matEl, "row").ToList();
+        var seRows = seEl is not null ? Els(seEl, "row").ToList() : [];
+        var shrinkRows = shrinkEl is not null ? Els(shrinkEl, "row").ToList() : [];
+
+        var result = new List<Parameter>(rows.Count);
+        for (var i = 0; i < rows.Count; i++)
+        {
+            var diagonalCol = Els(rows[i], "col").LastOrDefault();
+            var diagonalSe = i < seRows.Count
+                ? Els(seRows[i], "col").LastOrDefault()
+                : null;
+            // Shrinkage tables have one value per row (one per eta/eps).
+            var shrinkCol = i < shrinkRows.Count
+                ? Els(shrinkRows[i], "col").FirstOrDefault()
+                : null;
+
+            result.Add(new Parameter
+            {
+                Kind = kind,
+                Index = i + 1,
+                Label = Attr(rows[i], "rname")?.Trim(),
+                Estimate = diagonalCol is not null ? ParseDouble(diagonalCol.Value) : null,
+                StandardError = diagonalSe is not null ? ParseDouble(diagonalSe.Value) : null,
+                Shrinkage = shrinkCol is not null ? ParseDouble(shrinkCol.Value) : null,
+            });
+        }
+
+        return result;
+    }
+
+    private static double? ParseConditionNumber(XElement? covStatusEl)
+    {
+        if (covStatusEl is null)
+        {
+            return null;
+        }
+
+        var minVal = ParseDouble(Attr(covStatusEl, "mineigenvalue"));
+        var maxVal = ParseDouble(Attr(covStatusEl, "maxeigenvalue"));
+
+        if (minVal is null || maxVal is null || minVal == 0.0)
+        {
+            return null;
+        }
+
+        return maxVal / minVal;
+    }
+
+    private static List<string> ParseWarnings(XElement? statusEl, XElement? infoEl)
+    {
+        if (statusEl is null)
+        {
+            return [];
+        }
+
+        if (!int.TryParse(statusEl.Value.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var status) ||
+            status == 0)
+        {
+            return [];
+        }
+
+        var text = infoEl?.Value?.Trim();
+        return string.IsNullOrEmpty(text) ? [] : [text];
+    }
+
+    private static string DeriveRunNo(string sourcePath)
+    {
+        var stem = Path.GetFileNameWithoutExtension(sourcePath);
+
+        // Extract trailing digits. Works for "run27", "sim1", "1", etc.
+        var i = stem.Length - 1;
+        while (i >= 0 && char.IsDigit(stem[i]))
+        {
+            i--;
+        }
+
+        // If we found digits, return them; otherwise return the whole stem.
+        return i < stem.Length - 1 ? stem[(i + 1)..] : stem;
+    }
+
+    private static string ComputeMd5(string filePath)
+    {
+        var bytes = File.ReadAllBytes(filePath);
+        var hash = MD5.HashData(bytes);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    // Select by local name — transparent to nm: prefix used in real NONMEM output.
+    private static XElement? El(XContainer? parent, string localName) =>
+        parent?.Elements().FirstOrDefault(e => e.Name.LocalName == localName);
+
+    private static IEnumerable<XElement> Els(XContainer parent, string localName) =>
+        parent.Elements().Where(e => e.Name.LocalName == localName);
+
+    // Attribute lookup by local name (real NONMEM uses nm:name="..." on attributes too).
+    private static string? Attr(XElement? el, string localName) =>
+        el?.Attributes().FirstOrDefault(a => a.Name.LocalName == localName)?.Value;
+
+    private static double? ParseDouble(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return double.TryParse(value.Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out var d)
+            ? d
+            : null;
+    }
+
+    private static int? ParseInt(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return int.TryParse(value.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var i)
+            ? i
+            : null;
+    }
 }

--- a/src/Census.Import/NonmemXmlImporter.cs
+++ b/src/Census.Import/NonmemXmlImporter.cs
@@ -44,12 +44,32 @@ public sealed class NonmemXmlImporter : IRunImporter
 
         var runNo = DeriveRunNo(sourcePath);
 
+        // Comment defaults to the $PROBLEM title. A PsN run name, when we import one,
+        // takes precedence; until then the problem title is the best human label.
+        var problemTitle = El(firstProblem, "problem_title")?.Value?.Trim();
+
+        // Run-level timing: start/stop timestamps and total CPU time live on <output>.
+        var startDateTime = El(root, "start_datetime")?.Value?.Trim();
+        var stopDateTime = El(root, "stop_datetime")?.Value?.Trim();
+        var totalCpuTime = ParseDouble(El(root, "total_cputime")?.Value);
+
+        // Post-processing times live under <problem>/<post_process_times>.
+        var postTimes = El(firstProblem, "post_process_times");
+        var postElapsed = ParseDouble(El(postTimes, "post_elapsed_time")?.Value);
+        var finalOutputElapsed = ParseDouble(El(postTimes, "finaloutput_elapsed_time")?.Value);
+
         return new Run
         {
             RunNo = runNo,
             IRunNo = int.TryParse(runNo, NumberStyles.Integer, CultureInfo.InvariantCulture, out var n) ? n : 0,
+            Comment = string.IsNullOrEmpty(problemTitle) ? null : problemTitle,
             ObsRecs = obsRecs,
             Individuals = individuals,
+            StartDateTime = string.IsNullOrEmpty(startDateTime) ? null : startDateTime,
+            StopDateTime = string.IsNullOrEmpty(stopDateTime) ? null : stopDateTime,
+            TotalCpuTime = totalCpuTime,
+            PostElapsedTime = postElapsed,
+            FinalOutputElapsedTime = finalOutputElapsed,
             Estimations = estimations,
             Files = [],
         };
@@ -69,6 +89,8 @@ public sealed class NonmemXmlImporter : IRunImporter
             var method = El(estEl, "estimation_method")?.Value?.Trim();
             var ofv = ParseDouble(El(estEl, "final_objective_function")?.Value);
             var conditionNumber = ParseConditionNumber(El(estEl, "covariance_status"));
+            var estimationTime = ParseDouble(El(estEl, "estimation_elapsed_time")?.Value);
+            var covarianceTime = ParseDouble(El(estEl, "covariance_elapsed_time")?.Value);
 
             // Shrinkage: prefer etashrinksd (7.3+, SD-based) over etashrink (7.2 legacy).
             var etaShrinkEl = El(estEl, "etashrinksd") ?? El(estEl, "etashrink");
@@ -88,6 +110,8 @@ public sealed class NonmemXmlImporter : IRunImporter
                 Method = method,
                 Ofv = ofv,
                 ConditionNumber = conditionNumber,
+                EstimationTime = estimationTime,
+                CovarianceTime = covarianceTime,
                 Parameters = [.. thetas, .. omegas, .. sigmas],
                 Warnings = warnings,
             });

--- a/src/Census.Reports/Census.Reports.csproj
+++ b/src/Census.Reports/Census.Reports.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Templates\run_report.html" />
+    <EmbeddedResource Include="Templates\run_report.tex" />
   </ItemGroup>
 
 </Project>

--- a/src/Census.Reports/Census.Reports.csproj
+++ b/src/Census.Reports/Census.Reports.csproj
@@ -9,4 +9,8 @@
     <PackageReference Include="Scriban" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="Templates\run_report.html" />
+  </ItemGroup>
+
 </Project>

--- a/src/Census.Reports/CsvReportWriter.cs
+++ b/src/Census.Reports/CsvReportWriter.cs
@@ -1,0 +1,74 @@
+using System.Globalization;
+using System.IO;
+using Census.Domain;
+using CsvHelper;
+using CsvHelper.Configuration;
+
+namespace Census.Reports;
+
+/// <summary>
+/// Renders a run report as CSV using CsvHelper.
+/// Columns: RunNo, EstNo, Method, OFV, Kind, Index, Label, Estimate, SE, RSE_Pct,
+///          CI_Lower, CI_Upper, Shrinkage_Pct
+/// </summary>
+public sealed class CsvReportWriter : IReportWriter
+{
+    public ReportFormat Format => ReportFormat.Csv;
+
+    public string Render(Run run)
+    {
+        var config = new CsvConfiguration(CultureInfo.InvariantCulture)
+        {
+            HasHeaderRecord = true,
+            NewLine = "\n",
+        };
+
+        using var sw = new StringWriter();
+        using var csv = new CsvWriter(sw, config);
+
+        // Header
+        csv.WriteField("RunNo");
+        csv.WriteField("EstNo");
+        csv.WriteField("Method");
+        csv.WriteField("OFV");
+        csv.WriteField("Kind");
+        csv.WriteField("Index");
+        csv.WriteField("Label");
+        csv.WriteField("Estimate");
+        csv.WriteField("SE");
+        csv.WriteField("RSE_Pct");
+        csv.WriteField("CI_Lower");
+        csv.WriteField("CI_Upper");
+        csv.WriteField("Shrinkage_Pct");
+        csv.NextRecord();
+
+        foreach (var est in run.Estimations)
+        {
+            foreach (var param in est.Parameters)
+            {
+                var row = ParameterRow.FromParameter(param);
+
+                csv.WriteField(run.RunNo);
+                csv.WriteField(est.Number.ToString(CultureInfo.InvariantCulture));
+                csv.WriteField(est.Method ?? string.Empty);
+                csv.WriteField(FormatDouble(est.Ofv));
+                csv.WriteField(row.Kind);
+                csv.WriteField(row.Index.ToString(CultureInfo.InvariantCulture));
+                csv.WriteField(row.Label ?? string.Empty);
+                csv.WriteField(FormatDouble(row.Estimate));
+                csv.WriteField(FormatDouble(row.StandardError));
+                csv.WriteField(FormatDouble(row.Rse));
+                csv.WriteField(FormatDouble(row.CiLower));
+                csv.WriteField(FormatDouble(row.CiUpper));
+                csv.WriteField(FormatDouble(row.Shrinkage));
+                csv.NextRecord();
+            }
+        }
+
+        csv.Flush();
+        return sw.ToString();
+    }
+
+    private static string FormatDouble(double? value) =>
+        value.HasValue ? value.Value.ToString("G6", CultureInfo.InvariantCulture) : string.Empty;
+}

--- a/src/Census.Reports/HtmlReportWriter.cs
+++ b/src/Census.Reports/HtmlReportWriter.cs
@@ -1,0 +1,69 @@
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using Census.Domain;
+using Scriban;
+using Scriban.Runtime;
+
+namespace Census.Reports;
+
+/// <summary>
+/// Renders a run report as an HTML document using a Scriban template.
+/// </summary>
+public sealed class HtmlReportWriter : IReportWriter
+{
+    public ReportFormat Format => ReportFormat.Html;
+
+    private static readonly Template _template = LoadTemplate();
+
+    private static Template LoadTemplate()
+    {
+        var asm = typeof(HtmlReportWriter).Assembly;
+        using var stream = asm.GetManifestResourceStream(
+            "Census.Reports.Templates.run_report.html")!;
+        using var reader = new StreamReader(stream);
+        return Template.Parse(reader.ReadToEnd());
+    }
+
+    private static ScriptObject BuildModel(Run run)
+    {
+        var obj = new ScriptObject();
+        obj["run_no"] = run.RunNo;
+        obj["obs_recs"] = run.ObsRecs;
+        obj["individuals"] = run.Individuals;
+        obj["estimations"] = run.Estimations.Select(e => new ScriptObject
+        {
+            ["number"] = e.Number,
+            ["method"] = e.Method,
+            ["ofv"] = e.Ofv.HasValue ? e.Ofv.Value.ToString("G6", CultureInfo.InvariantCulture) : "",
+            ["condition_number"] = e.ConditionNumber.HasValue ? e.ConditionNumber.Value.ToString("G6", CultureInfo.InvariantCulture) : "",
+            ["warnings"] = e.Warnings.ToList(),
+            ["parameters"] = e.Parameters.Select(p =>
+            {
+                var row = ParameterRow.FromParameter(p);
+                var ps = new ScriptObject();
+                ps["kind"] = row.Kind;
+                ps["index"] = row.Index;
+                ps["label"] = row.Label ?? "";
+                ps["estimate"] = FormatG4(row.Estimate);
+                ps["se"] = FormatG4(row.StandardError);
+                ps["rse"] = FormatG4(row.Rse);
+                ps["ci_lower"] = FormatG4(row.CiLower);
+                ps["ci_upper"] = FormatG4(row.CiUpper);
+                ps["shrinkage"] = FormatG4(row.Shrinkage);
+                return ps;
+            }).ToList(),
+        }).ToList();
+        return obj;
+    }
+
+    private static string FormatG4(double? v) =>
+        v.HasValue ? v.Value.ToString("G4", CultureInfo.InvariantCulture) : "";
+
+    public string Render(Run run)
+    {
+        var ctx = new TemplateContext { StrictVariables = false };
+        ctx.PushGlobal(BuildModel(run));
+        return _template.Render(ctx);
+    }
+}

--- a/src/Census.Reports/LatexReportWriter.cs
+++ b/src/Census.Reports/LatexReportWriter.cs
@@ -1,0 +1,94 @@
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Census.Domain;
+using Scriban;
+using Scriban.Runtime;
+
+namespace Census.Reports;
+
+/// <summary>
+/// Renders a run report as a LaTeX document using a Scriban template.
+/// </summary>
+public sealed class LatexReportWriter : IReportWriter
+{
+    public ReportFormat Format => ReportFormat.Latex;
+
+    private static readonly Template _template = LoadTemplate();
+
+    private static Template LoadTemplate()
+    {
+        var asm = typeof(LatexReportWriter).Assembly;
+        using var stream = asm.GetManifestResourceStream(
+            "Census.Reports.Templates.run_report.tex")!;
+        using var reader = new StreamReader(stream);
+        return Template.Parse(reader.ReadToEnd());
+    }
+
+    /// <summary>
+    /// Escapes a string for safe use inside a LaTeX document.
+    /// Returns an empty string when <paramref name="s"/> is null.
+    /// </summary>
+    internal static string LatexEscape(string? s)
+    {
+        if (s is null) return "";
+
+        // Process in order: backslash first so the replacements we add next
+        // don't themselves get escaped.
+        var sb = new StringBuilder(s);
+        sb.Replace("\\", "\\textbackslash{}");
+        sb.Replace("{", "\\{");
+        sb.Replace("}", "\\}");
+        sb.Replace("$", "\\$");
+        sb.Replace("&", "\\&");
+        sb.Replace("#", "\\#");
+        sb.Replace("^", "\\textasciicircum{}");
+        sb.Replace("_", "\\_");
+        sb.Replace("~", "\\textasciitilde{}");
+        sb.Replace("%", "\\%");
+        return sb.ToString();
+    }
+
+    private static ScriptObject BuildModel(Run run)
+    {
+        var obj = new ScriptObject();
+        obj["run_no"] = LatexEscape(run.RunNo);
+        obj["obs_recs"] = run.ObsRecs;
+        obj["individuals"] = run.Individuals;
+        obj["estimations"] = run.Estimations.Select(e => new ScriptObject
+        {
+            ["number"] = e.Number,
+            ["method"] = LatexEscape(e.Method),
+            ["ofv"] = e.Ofv.HasValue ? e.Ofv.Value.ToString("G6", CultureInfo.InvariantCulture) : "",
+            ["condition_number"] = e.ConditionNumber.HasValue ? e.ConditionNumber.Value.ToString("G6", CultureInfo.InvariantCulture) : "",
+            ["warnings"] = e.Warnings.Select(w => LatexEscape(w)).ToList(),
+            ["parameters"] = e.Parameters.Select(p =>
+            {
+                var row = ParameterRow.FromParameter(p);
+                var ps = new ScriptObject();
+                ps["kind"] = row.Kind;
+                ps["index"] = row.Index;
+                ps["label"] = LatexEscape(row.Label);
+                ps["estimate"] = FormatG4(row.Estimate);
+                ps["se"] = FormatG4(row.StandardError);
+                ps["rse"] = FormatG4(row.Rse);
+                ps["ci_lower"] = FormatG4(row.CiLower);
+                ps["ci_upper"] = FormatG4(row.CiUpper);
+                ps["shrinkage"] = FormatG4(row.Shrinkage);
+                return ps;
+            }).ToList(),
+        }).ToList();
+        return obj;
+    }
+
+    private static string FormatG4(double? v) =>
+        v.HasValue ? v.Value.ToString("G4", CultureInfo.InvariantCulture) : "";
+
+    public string Render(Run run)
+    {
+        var ctx = new TemplateContext { StrictVariables = false };
+        ctx.PushGlobal(BuildModel(run));
+        return _template.Render(ctx);
+    }
+}

--- a/src/Census.Reports/ParameterRow.cs
+++ b/src/Census.Reports/ParameterRow.cs
@@ -6,7 +6,7 @@ namespace Census.Reports;
 /// <summary>
 /// Computed view model for one parameter row in a report.
 /// </summary>
-internal readonly record struct ParameterRow
+public readonly record struct ParameterRow
 {
     public string Kind { get; init; }
     public int Index { get; init; }

--- a/src/Census.Reports/ParameterRow.cs
+++ b/src/Census.Reports/ParameterRow.cs
@@ -1,0 +1,56 @@
+using System.Globalization;
+using Census.Domain;
+
+namespace Census.Reports;
+
+/// <summary>
+/// Computed view model for one parameter row in a report.
+/// </summary>
+internal readonly record struct ParameterRow
+{
+    public string Kind { get; init; }
+    public int Index { get; init; }
+    public string? Label { get; init; }
+    public double? Estimate { get; init; }
+    public double? StandardError { get; init; }
+    public double? Rse { get; init; }
+    public double? CiLower { get; init; }
+    public double? CiUpper { get; init; }
+    public double? Shrinkage { get; init; }
+
+    public static ParameterRow FromParameter(Parameter p)
+    {
+        string kind = p.Kind switch
+        {
+            ParameterKind.Theta => "THETA",
+            ParameterKind.Omega => "OMEGA",
+            ParameterKind.Sigma => "SIGMA",
+            _ => p.Kind.ToString().ToUpperInvariant(),
+        };
+
+        double? rse = (p.StandardError.HasValue && p.Estimate.HasValue && p.Estimate.Value != 0.0)
+            ? (p.StandardError.Value / Math.Abs(p.Estimate.Value)) * 100.0
+            : null;
+
+        double? ciLower = (p.Estimate.HasValue && p.StandardError.HasValue)
+            ? p.Estimate.Value - 1.96 * p.StandardError.Value
+            : null;
+
+        double? ciUpper = (p.Estimate.HasValue && p.StandardError.HasValue)
+            ? p.Estimate.Value + 1.96 * p.StandardError.Value
+            : null;
+
+        return new ParameterRow
+        {
+            Kind = kind,
+            Index = p.Index,
+            Label = p.Label,
+            Estimate = p.Estimate,
+            StandardError = p.StandardError,
+            Rse = rse,
+            CiLower = ciLower,
+            CiUpper = ciUpper,
+            Shrinkage = p.Shrinkage,
+        };
+    }
+}

--- a/src/Census.Reports/Templates/run_report.html
+++ b/src/Census.Reports/Templates/run_report.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Census Run Report &#8211; {{ run_no }}</title>
+  <style>
+    body { font-family: Arial, sans-serif; font-size: 11pt; margin: 2cm; }
+    table { border-collapse: collapse; width: 100%; margin-bottom: 1em; }
+    th, td { border: 1px solid #888; padding: 4px 8px; text-align: left; }
+    th { background: #dde; }
+    .section-theta td:first-child { font-style: italic; }
+    caption { text-align: left; font-weight: bold; margin-bottom: 4px; }
+  </style>
+</head>
+<body>
+<h1>Run {{ run_no }}</h1>
+{{ if obs_recs }}<p>Observations: {{ obs_recs }}{{ if individuals }}, Individuals: {{ individuals }}{{ end }}</p>{{ end }}
+
+{{ for est in estimations }}
+<h2>Estimation {{ est.number }}{{ if est.method }} ({{ est.method }}){{ end }}</h2>
+{{ if est.ofv }}<p>OFV: {{ est.ofv }}{{ if est.condition_number }}, Condition number: {{ est.condition_number }}{{ end }}</p>{{ end }}
+
+{{ if est.warnings }}
+<ul>{{ for w in est.warnings }}<li>{{ w }}</li>{{ end }}</ul>
+{{ end }}
+
+<table>
+  <thead>
+    <tr>
+      <th>No.</th><th>Parameter</th><th>Estimate</th><th>S.E.</th>
+      <th>%RSE</th><th>95% CI</th><th>Shrinkage&nbsp;(%)</th>
+    </tr>
+  </thead>
+  <tbody>
+  {{ for p in est.parameters }}
+    <tr>
+      <td>{{ p.kind }}{{ p.index }}</td>
+      <td>{{ p.label }}</td>
+      <td>{{ p.estimate }}</td>
+      <td>{{ p.se }}</td>
+      <td>{{ p.rse }}</td>
+      <td>{{ if p.ci_lower != "" }}{{ p.ci_lower }}&nbsp;&#8211;&nbsp;{{ p.ci_upper }}{{ end }}</td>
+      <td>{{ p.shrinkage }}</td>
+    </tr>
+  {{ end }}
+  </tbody>
+</table>
+{{ end }}
+</body>
+</html>

--- a/src/Census.Reports/Templates/run_report.tex
+++ b/src/Census.Reports/Templates/run_report.tex
@@ -1,0 +1,30 @@
+\documentclass[12pt]{article}
+\usepackage[margin=2cm]{geometry}
+\usepackage{longtable}
+\usepackage{booktabs}
+\begin{document}
+
+\section*{Run {{ run_no }}}
+{{ if obs_recs }}Observations: {{ obs_recs }}{{ if individuals }}, Individuals: {{ individuals }}{{ end }}\\{{ end }}
+
+{{ for est in estimations }}
+\subsection*{Estimation {{ est.number }}{{ if est.method }} ({{ est.method }}){{ end }}}
+{{ if est.ofv }}OFV: {{ est.ofv }}{{ if est.condition_number }}, Condition number: {{ est.condition_number }}{{ end }}\\{{ end }}
+
+{{ if est.warnings }}
+\begin{itemize}
+{{ for w in est.warnings }}\item {{ w }}
+{{ end }}\end{itemize}
+{{ end }}
+
+\begin{longtable}{llrrrrl}
+\toprule
+No. & Parameter & Estimate & S.E. & \%RSE & 95\% CI & Shrinkage (\%) \\
+\midrule
+\endhead
+{{ for p in est.parameters }}{{ p.kind }}{{ p.index }} & {{ p.label }} & {{ p.estimate }} & {{ p.se }} & {{ p.rse }} & {{ if p.ci_lower != "" }}{{ p.ci_lower }}--{{ p.ci_upper }}{{ end }} & {{ p.shrinkage }} \\
+{{ end }}\bottomrule
+\end{longtable}
+
+{{ end }}
+\end{document}

--- a/src/Census.Storage/Census.Storage.csproj
+++ b/src/Census.Storage/Census.Storage.csproj
@@ -6,8 +6,11 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" />
-    <PackageReference Include="dbup-sqlite" />
     <PackageReference Include="Microsoft.Data.Sqlite" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Migrations\*.sql" />
   </ItemGroup>
 
 </Project>

--- a/src/Census.Storage/IProjectStore.cs
+++ b/src/Census.Storage/IProjectStore.cs
@@ -20,4 +20,7 @@ public interface IProjectStore
 
     /// <summary>Load all runs in the project.</summary>
     IReadOnlyList<Run> GetRuns();
+
+    /// <summary>Delete a run (and its estimations, parameters, warnings and file refs) by run number.</summary>
+    void DeleteRun(string runNo);
 }

--- a/src/Census.Storage/Migrations/0001_initial.sql
+++ b/src/Census.Storage/Migrations/0001_initial.sql
@@ -1,0 +1,55 @@
+-- Census project schema, version 1.
+-- Clean design for Microsoft.Data.Sqlite. No backward compatibility with
+-- Lazarus-era .cen files is required or attempted.
+
+CREATE TABLE runs (
+    Id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    RunNo       TEXT    NOT NULL,
+    IRunNo      INTEGER NOT NULL,
+    ParentNo    TEXT,
+    Comment     TEXT,
+    KeyRun      INTEGER NOT NULL DEFAULT 0,
+    ObsRecs     INTEGER,
+    Individuals INTEGER,
+    CreatedUtc  TEXT    NOT NULL
+);
+CREATE INDEX ix_runs_runno ON runs (RunNo);
+CREATE UNIQUE INDEX ux_runs_irunno ON runs (IRunNo);
+
+CREATE TABLE estimations (
+    Id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    RunId           INTEGER NOT NULL REFERENCES runs (Id) ON DELETE CASCADE,
+    Number          INTEGER NOT NULL,
+    Method          TEXT,
+    Ofv             REAL,
+    DOfv            REAL,
+    ConditionNumber REAL
+);
+CREATE INDEX ix_estimations_run ON estimations (RunId);
+
+CREATE TABLE parameters (
+    Id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    EstimationId  INTEGER NOT NULL REFERENCES estimations (Id) ON DELETE CASCADE,
+    Kind          TEXT    NOT NULL,            -- theta | omega | sigma
+    "Index"       INTEGER NOT NULL,
+    Label         TEXT,
+    Estimate      REAL,
+    StandardError REAL,
+    Shrinkage     REAL
+);
+CREATE INDEX ix_parameters_estimation ON parameters (EstimationId);
+
+CREATE TABLE warnings (
+    Id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    EstimationId INTEGER NOT NULL REFERENCES estimations (Id) ON DELETE CASCADE,
+    Text         TEXT    NOT NULL
+);
+
+CREATE TABLE file_artifacts (
+    Id    INTEGER PRIMARY KEY AUTOINCREMENT,
+    RunId INTEGER NOT NULL REFERENCES runs (Id) ON DELETE CASCADE,
+    Role  TEXT    NOT NULL,
+    Path  TEXT    NOT NULL,
+    Md5   TEXT
+);
+CREATE INDEX ix_file_artifacts_run ON file_artifacts (RunId);

--- a/src/Census.Storage/Migrations/0002_timing.sql
+++ b/src/Census.Storage/Migrations/0002_timing.sql
@@ -1,0 +1,12 @@
+-- Census project schema, version 2.
+-- Adds NONMEM timing fields: per-estimation elapsed times and run-level
+-- start/stop timestamps, total CPU time, and post-processing times.
+
+ALTER TABLE estimations ADD COLUMN EstimationTime REAL;
+ALTER TABLE estimations ADD COLUMN CovarianceTime REAL;
+
+ALTER TABLE runs ADD COLUMN StartDateTime          TEXT;
+ALTER TABLE runs ADD COLUMN StopDateTime           TEXT;
+ALTER TABLE runs ADD COLUMN TotalCpuTime           REAL;
+ALTER TABLE runs ADD COLUMN PostElapsedTime        REAL;
+ALTER TABLE runs ADD COLUMN FinalOutputElapsedTime REAL;

--- a/src/Census.Storage/Migrator.cs
+++ b/src/Census.Storage/Migrator.cs
@@ -1,0 +1,74 @@
+using System.Globalization;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Dapper;
+using Microsoft.Data.Sqlite;
+
+namespace Census.Storage;
+
+/// <summary>
+/// Minimal forward-only migration runner. Embedded <c>NNNN_name.sql</c> scripts are applied
+/// in numeric order inside a transaction, and the highest applied version is recorded in a
+/// <c>schema_version</c> metadata table. Idempotent: already-applied scripts are skipped.
+/// </summary>
+public static partial class Migrator
+{
+    public static void Apply(SqliteConnection connection)
+    {
+        connection.Execute(
+            "CREATE TABLE IF NOT EXISTS schema_version (" +
+            "Version INTEGER NOT NULL PRIMARY KEY, AppliedUtc TEXT NOT NULL);");
+
+        var current = connection.ExecuteScalar<long?>(
+            "SELECT MAX(Version) FROM schema_version") ?? 0;
+
+        foreach (var (version, sql) in LoadScripts())
+        {
+            if (version <= current)
+            {
+                continue;
+            }
+
+            using var tx = connection.BeginTransaction();
+            connection.Execute(sql, transaction: tx);
+            connection.Execute(
+                "INSERT INTO schema_version (Version, AppliedUtc) VALUES (@version, @applied);",
+                new { version, applied = DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture) },
+                tx);
+            tx.Commit();
+        }
+    }
+
+    /// <summary>The schema version this build expects (the highest embedded script).</summary>
+    public static int LatestVersion() => LoadScripts().Max(s => s.Version);
+
+    private static List<(int Version, string Sql)> LoadScripts()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        var scripts = new List<(int Version, string Sql)>();
+
+        foreach (var resource in assembly.GetManifestResourceNames())
+        {
+            if (!resource.EndsWith(".sql", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var match = VersionPrefix().Match(resource);
+            if (!match.Success)
+            {
+                continue;
+            }
+
+            using var stream = assembly.GetManifestResourceStream(resource)!;
+            using var reader = new StreamReader(stream);
+            scripts.Add((int.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture), reader.ReadToEnd()));
+        }
+
+        return scripts.OrderBy(s => s.Version).ToList();
+    }
+
+    // Matches the NNNN_ numeric prefix in a resource name like "Census.Storage.Migrations.0001_initial.sql".
+    [GeneratedRegex(@"\.(\d+)_[^.]*\.sql$", RegexOptions.IgnoreCase)]
+    private static partial Regex VersionPrefix();
+}

--- a/src/Census.Storage/SqliteProjectStore.cs
+++ b/src/Census.Storage/SqliteProjectStore.cs
@@ -174,6 +174,14 @@ public sealed class SqliteProjectStore : IProjectStore
         return runs;
     }
 
+    public void DeleteRun(string runNo)
+    {
+        using var connection = OpenConnection();
+        // Child rows (estimations, parameters, warnings, file_artifacts) are removed
+        // by ON DELETE CASCADE; ForeignKeys=true in the connection string enables it.
+        connection.Execute("DELETE FROM runs WHERE RunNo = @runNo;", new { runNo });
+    }
+
     private SqliteConnection OpenConnection()
     {
         var connection = new SqliteConnection(ConnectionString);

--- a/src/Census.Storage/SqliteProjectStore.cs
+++ b/src/Census.Storage/SqliteProjectStore.cs
@@ -1,0 +1,191 @@
+using System.Globalization;
+using Census.Domain;
+using Dapper;
+using Microsoft.Data.Sqlite;
+
+namespace Census.Storage;
+
+/// <summary>
+/// SQLite-backed <see cref="IProjectStore"/> using Microsoft.Data.Sqlite and Dapper.
+/// The schema is created and upgraded by the embedded migration scripts (<see cref="Migrator"/>).
+/// </summary>
+public sealed class SqliteProjectStore : IProjectStore
+{
+    private string? _path;
+
+    private string ConnectionString =>
+        new SqliteConnectionStringBuilder
+        {
+            DataSource = _path ?? throw new InvalidOperationException("No project is open. Call Create or Open first."),
+            ForeignKeys = true,
+        }.ToString();
+
+    public void Create(string path)
+    {
+        _path = path;
+        using var connection = OpenConnection();
+        Migrator.Apply(connection);
+    }
+
+    public void Open(string path)
+    {
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException("Project file not found.", path);
+        }
+
+        _path = path;
+        using var connection = OpenConnection();
+        Migrator.Apply(connection);
+    }
+
+    public void SaveRun(Run run)
+    {
+        using var connection = OpenConnection();
+        using var tx = connection.BeginTransaction();
+
+        var runId = connection.ExecuteScalar<long>(
+            """
+            INSERT INTO runs (RunNo, IRunNo, ParentNo, Comment, KeyRun, ObsRecs, Individuals, CreatedUtc)
+            VALUES (@RunNo, @IRunNo, @ParentNo, @Comment, @KeyRun, @ObsRecs, @Individuals, @CreatedUtc);
+            SELECT last_insert_rowid();
+            """,
+            new
+            {
+                run.RunNo,
+                run.IRunNo,
+                run.ParentNo,
+                run.Comment,
+                KeyRun = run.KeyRun ? 1 : 0,
+                run.ObsRecs,
+                run.Individuals,
+                CreatedUtc = DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture),
+            },
+            tx);
+
+        foreach (var artifact in run.Files)
+        {
+            connection.Execute(
+                "INSERT INTO file_artifacts (RunId, Role, Path, Md5) VALUES (@runId, @Role, @Path, @Md5);",
+                new { runId, artifact.Role, artifact.Path, artifact.Md5 },
+                tx);
+        }
+
+        foreach (var estimation in run.Estimations)
+        {
+            var estId = connection.ExecuteScalar<long>(
+                """
+                INSERT INTO estimations (RunId, Number, Method, Ofv, DOfv, ConditionNumber)
+                VALUES (@runId, @Number, @Method, @Ofv, @DOfv, @ConditionNumber);
+                SELECT last_insert_rowid();
+                """,
+                new { runId, estimation.Number, estimation.Method, estimation.Ofv, estimation.DOfv, estimation.ConditionNumber },
+                tx);
+
+            foreach (var p in estimation.Parameters)
+            {
+                connection.Execute(
+                    """
+                    INSERT INTO parameters (EstimationId, Kind, "Index", Label, Estimate, StandardError, Shrinkage)
+                    VALUES (@estId, @Kind, @Index, @Label, @Estimate, @StandardError, @Shrinkage);
+                    """,
+                    new { estId, Kind = p.Kind.ToString().ToLowerInvariant(), p.Index, p.Label, p.Estimate, p.StandardError, p.Shrinkage },
+                    tx);
+            }
+
+            foreach (var warning in estimation.Warnings)
+            {
+                connection.Execute(
+                    "INSERT INTO warnings (EstimationId, Text) VALUES (@estId, @warning);",
+                    new { estId, warning },
+                    tx);
+            }
+        }
+
+        tx.Commit();
+    }
+
+    public IReadOnlyList<Run> GetRuns()
+    {
+        using var connection = OpenConnection();
+
+        var runRows = connection.Query<RunRow>(
+            "SELECT Id, RunNo, IRunNo, ParentNo, Comment, KeyRun, ObsRecs, Individuals FROM runs ORDER BY IRunNo;")
+            .ToList();
+
+        var runs = new List<Run>(runRows.Count);
+        foreach (var r in runRows)
+        {
+            var files = connection.Query<FileArtifact>(
+                "SELECT Role, Path, Md5 FROM file_artifacts WHERE RunId = @id ORDER BY Id;",
+                new { id = r.Id }).ToList();
+
+            var estRows = connection.Query<EstimationRow>(
+                "SELECT Id, Number, Method, Ofv, DOfv, ConditionNumber FROM estimations WHERE RunId = @id ORDER BY Number;",
+                new { id = r.Id }).ToList();
+
+            var estimations = new List<Estimation>(estRows.Count);
+            foreach (var e in estRows)
+            {
+                var parameters = connection.Query<ParameterRow>(
+                    """SELECT Kind, "Index", Label, Estimate, StandardError, Shrinkage FROM parameters WHERE EstimationId = @id ORDER BY Id;""",
+                    new { id = e.Id })
+                    .Select(p => new Parameter
+                    {
+                        Kind = Enum.Parse<ParameterKind>(p.Kind, ignoreCase: true),
+                        Index = (int)p.Index,
+                        Label = p.Label,
+                        Estimate = p.Estimate,
+                        StandardError = p.StandardError,
+                        Shrinkage = p.Shrinkage,
+                    })
+                    .ToList();
+
+                var warnings = connection.Query<string>(
+                    "SELECT Text FROM warnings WHERE EstimationId = @id ORDER BY Id;",
+                    new { id = e.Id }).ToList();
+
+                estimations.Add(new Estimation
+                {
+                    Number = (int)e.Number,
+                    Method = e.Method,
+                    Ofv = e.Ofv,
+                    DOfv = e.DOfv,
+                    ConditionNumber = e.ConditionNumber,
+                    Parameters = parameters,
+                    Warnings = warnings,
+                });
+            }
+
+            runs.Add(new Run
+            {
+                RunNo = r.RunNo,
+                IRunNo = (int)r.IRunNo,
+                ParentNo = r.ParentNo,
+                Comment = r.Comment,
+                KeyRun = r.KeyRun != 0,
+                ObsRecs = (int?)r.ObsRecs,
+                Individuals = (int?)r.Individuals,
+                Files = files,
+                Estimations = estimations,
+            });
+        }
+
+        return runs;
+    }
+
+    private SqliteConnection OpenConnection()
+    {
+        var connection = new SqliteConnection(ConnectionString);
+        connection.Open();
+        return connection;
+    }
+
+    // Row DTOs for Dapper mapping. SQLite returns INTEGER columns as Int64, so these use
+    // long/long? to match; conversion to the domain's int types happens at the call site.
+    private sealed record RunRow(long Id, string RunNo, long IRunNo, string? ParentNo, string? Comment, long KeyRun, long? ObsRecs, long? Individuals);
+
+    private sealed record EstimationRow(long Id, long Number, string? Method, double? Ofv, double? DOfv, double? ConditionNumber);
+
+    private sealed record ParameterRow(string Kind, long Index, string? Label, double? Estimate, double? StandardError, double? Shrinkage);
+}

--- a/src/Census.Storage/SqliteProjectStore.cs
+++ b/src/Census.Storage/SqliteProjectStore.cs
@@ -46,8 +46,10 @@ public sealed class SqliteProjectStore : IProjectStore
 
         var runId = connection.ExecuteScalar<long>(
             """
-            INSERT INTO runs (RunNo, IRunNo, ParentNo, Comment, KeyRun, ObsRecs, Individuals, CreatedUtc)
-            VALUES (@RunNo, @IRunNo, @ParentNo, @Comment, @KeyRun, @ObsRecs, @Individuals, @CreatedUtc);
+            INSERT INTO runs (RunNo, IRunNo, ParentNo, Comment, KeyRun, ObsRecs, Individuals,
+                              StartDateTime, StopDateTime, TotalCpuTime, PostElapsedTime, FinalOutputElapsedTime, CreatedUtc)
+            VALUES (@RunNo, @IRunNo, @ParentNo, @Comment, @KeyRun, @ObsRecs, @Individuals,
+                    @StartDateTime, @StopDateTime, @TotalCpuTime, @PostElapsedTime, @FinalOutputElapsedTime, @CreatedUtc);
             SELECT last_insert_rowid();
             """,
             new
@@ -59,6 +61,11 @@ public sealed class SqliteProjectStore : IProjectStore
                 KeyRun = run.KeyRun ? 1 : 0,
                 run.ObsRecs,
                 run.Individuals,
+                run.StartDateTime,
+                run.StopDateTime,
+                run.TotalCpuTime,
+                run.PostElapsedTime,
+                run.FinalOutputElapsedTime,
                 CreatedUtc = DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture),
             },
             tx);
@@ -75,11 +82,11 @@ public sealed class SqliteProjectStore : IProjectStore
         {
             var estId = connection.ExecuteScalar<long>(
                 """
-                INSERT INTO estimations (RunId, Number, Method, Ofv, DOfv, ConditionNumber)
-                VALUES (@runId, @Number, @Method, @Ofv, @DOfv, @ConditionNumber);
+                INSERT INTO estimations (RunId, Number, Method, Ofv, DOfv, ConditionNumber, EstimationTime, CovarianceTime)
+                VALUES (@runId, @Number, @Method, @Ofv, @DOfv, @ConditionNumber, @EstimationTime, @CovarianceTime);
                 SELECT last_insert_rowid();
                 """,
-                new { runId, estimation.Number, estimation.Method, estimation.Ofv, estimation.DOfv, estimation.ConditionNumber },
+                new { runId, estimation.Number, estimation.Method, estimation.Ofv, estimation.DOfv, estimation.ConditionNumber, estimation.EstimationTime, estimation.CovarianceTime },
                 tx);
 
             foreach (var p in estimation.Parameters)
@@ -110,7 +117,11 @@ public sealed class SqliteProjectStore : IProjectStore
         using var connection = OpenConnection();
 
         var runRows = connection.Query<RunRow>(
-            "SELECT Id, RunNo, IRunNo, ParentNo, Comment, KeyRun, ObsRecs, Individuals FROM runs ORDER BY IRunNo;")
+            """
+            SELECT Id, RunNo, IRunNo, ParentNo, Comment, KeyRun, ObsRecs, Individuals,
+                   StartDateTime, StopDateTime, TotalCpuTime, PostElapsedTime, FinalOutputElapsedTime
+            FROM runs ORDER BY IRunNo;
+            """)
             .ToList();
 
         var runs = new List<Run>(runRows.Count);
@@ -121,7 +132,7 @@ public sealed class SqliteProjectStore : IProjectStore
                 new { id = r.Id }).ToList();
 
             var estRows = connection.Query<EstimationRow>(
-                "SELECT Id, Number, Method, Ofv, DOfv, ConditionNumber FROM estimations WHERE RunId = @id ORDER BY Number;",
+                "SELECT Id, Number, Method, Ofv, DOfv, ConditionNumber, EstimationTime, CovarianceTime FROM estimations WHERE RunId = @id ORDER BY Number;",
                 new { id = r.Id }).ToList();
 
             var estimations = new List<Estimation>(estRows.Count);
@@ -152,6 +163,8 @@ public sealed class SqliteProjectStore : IProjectStore
                     Ofv = e.Ofv,
                     DOfv = e.DOfv,
                     ConditionNumber = e.ConditionNumber,
+                    EstimationTime = e.EstimationTime,
+                    CovarianceTime = e.CovarianceTime,
                     Parameters = parameters,
                     Warnings = warnings,
                 });
@@ -166,6 +179,11 @@ public sealed class SqliteProjectStore : IProjectStore
                 KeyRun = r.KeyRun != 0,
                 ObsRecs = (int?)r.ObsRecs,
                 Individuals = (int?)r.Individuals,
+                StartDateTime = r.StartDateTime,
+                StopDateTime = r.StopDateTime,
+                TotalCpuTime = r.TotalCpuTime,
+                PostElapsedTime = r.PostElapsedTime,
+                FinalOutputElapsedTime = r.FinalOutputElapsedTime,
                 Files = files,
                 Estimations = estimations,
             });
@@ -191,9 +209,10 @@ public sealed class SqliteProjectStore : IProjectStore
 
     // Row DTOs for Dapper mapping. SQLite returns INTEGER columns as Int64, so these use
     // long/long? to match; conversion to the domain's int types happens at the call site.
-    private sealed record RunRow(long Id, string RunNo, long IRunNo, string? ParentNo, string? Comment, long KeyRun, long? ObsRecs, long? Individuals);
+    private sealed record RunRow(long Id, string RunNo, long IRunNo, string? ParentNo, string? Comment, long KeyRun, long? ObsRecs, long? Individuals,
+        string? StartDateTime, string? StopDateTime, double? TotalCpuTime, double? PostElapsedTime, double? FinalOutputElapsedTime);
 
-    private sealed record EstimationRow(long Id, long Number, string? Method, double? Ofv, double? DOfv, double? ConditionNumber);
+    private sealed record EstimationRow(long Id, long Number, string? Method, double? Ofv, double? DOfv, double? ConditionNumber, double? EstimationTime, double? CovarianceTime);
 
     private sealed record ParameterRow(string Kind, long Index, string? Label, double? Estimate, double? StandardError, double? Shrinkage);
 }

--- a/tests/Census.Tests/ArchiveTests.cs
+++ b/tests/Census.Tests/ArchiveTests.cs
@@ -1,0 +1,207 @@
+using System.IO.Compression;
+using System.Text.Json;
+using Census.Archive;
+using Census.Domain;
+using Xunit;
+
+namespace Census.Tests;
+
+public sealed class ArchiveTests
+{
+    // -----------------------------------------------------------------------
+    // Test 1 — existing files are included in the ZIP
+    // -----------------------------------------------------------------------
+    [Fact]
+    public void Archive_ExistingFiles_ZipContainsEntries()
+    {
+        var file1 = Path.GetTempFileName();
+        var file2 = Path.GetTempFileName();
+        var zipPath = Path.ChangeExtension(Path.GetTempFileName(), ".zip");
+
+        try
+        {
+            File.WriteAllText(file1, "content1");
+            File.WriteAllText(file2, "content2");
+
+            var run = new Run
+            {
+                RunNo = "1",
+                Files =
+                [
+                    new FileArtifact { Role = "output", Path = file1 },
+                    new FileArtifact { Role = "output", Path = file2 },
+                ],
+            };
+
+            new RunArchiver().Archive(run, zipPath, includeData: true);
+
+            using var archive = ZipFile.OpenRead(zipPath);
+            Assert.Equal(3, archive.Entries.Count); // 2 files + manifest
+        }
+        finally
+        {
+            TryDelete(file1, file2, zipPath);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 2 — data-role artifacts are skipped when includeData = false
+    // -----------------------------------------------------------------------
+    [Fact]
+    public void Archive_SkipsDataRoleWhenFlagFalse()
+    {
+        var outputFile = Path.GetTempFileName();
+        var dataFile = Path.GetTempFileName();
+        var zipPath = Path.ChangeExtension(Path.GetTempFileName(), ".zip");
+
+        try
+        {
+            File.WriteAllText(outputFile, "output");
+            File.WriteAllText(dataFile, "data");
+
+            var run = new Run
+            {
+                RunNo = "2",
+                Files =
+                [
+                    new FileArtifact { Role = "output", Path = outputFile },
+                    new FileArtifact { Role = "data",   Path = dataFile   },
+                ],
+            };
+
+            new RunArchiver().Archive(run, zipPath, includeData: false);
+
+            using var archive = ZipFile.OpenRead(zipPath);
+            Assert.Equal(2, archive.Entries.Count); // 1 output + manifest
+        }
+        finally
+        {
+            TryDelete(outputFile, dataFile, zipPath);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 3 — missing files are silently skipped (no exception)
+    // -----------------------------------------------------------------------
+    [Fact]
+    public void Archive_MissingFilesSkipped()
+    {
+        var zipPath = Path.ChangeExtension(Path.GetTempFileName(), ".zip");
+
+        try
+        {
+            var run = new Run
+            {
+                RunNo = "3",
+                Files =
+                [
+                    new FileArtifact { Role = "output", Path = @"C:\does\not\exist\file.xml" },
+                ],
+            };
+
+            // Must not throw.
+            new RunArchiver().Archive(run, zipPath, includeData: true);
+
+            using var archive = ZipFile.OpenRead(zipPath);
+            Assert.Single(archive.Entries); // manifest only
+        }
+        finally
+        {
+            TryDelete(zipPath);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 4 — manifest JSON contains the run number
+    // -----------------------------------------------------------------------
+    [Fact]
+    public void Archive_ManifestContainsRunNo()
+    {
+        var zipPath = Path.ChangeExtension(Path.GetTempFileName(), ".zip");
+
+        try
+        {
+            var run = new Run { RunNo = "27" };
+
+            new RunArchiver().Archive(run, zipPath, includeData: true);
+
+            using var archive = ZipFile.OpenRead(zipPath);
+            var manifestEntry = archive.GetEntry("census_manifest.json");
+            Assert.NotNull(manifestEntry);
+
+            using var stream = manifestEntry.Open();
+            var doc = JsonDocument.Parse(stream);
+            Assert.Equal("27", doc.RootElement.GetProperty("RunNo").GetString());
+        }
+        finally
+        {
+            TryDelete(zipPath);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 5 — duplicate filenames in different directories get unique entries
+    // -----------------------------------------------------------------------
+    [Fact]
+    public void Archive_DuplicateFilenames_UniqueEntries()
+    {
+        // Create two temp directories so we can give both files the same name.
+        var dir1 = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var dir2 = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var zipPath = Path.ChangeExtension(Path.GetTempFileName(), ".zip");
+
+        try
+        {
+            Directory.CreateDirectory(dir1);
+            Directory.CreateDirectory(dir2);
+
+            const string sharedName = "run27.xml";
+            var file1 = Path.Combine(dir1, sharedName);
+            var file2 = Path.Combine(dir2, sharedName);
+
+            File.WriteAllText(file1, "v1");
+            File.WriteAllText(file2, "v2");
+
+            var run = new Run
+            {
+                RunNo = "27",
+                Files =
+                [
+                    new FileArtifact { Role = "output", Path = file1 },
+                    new FileArtifact { Role = "output", Path = file2 },
+                ],
+            };
+
+            new RunArchiver().Archive(run, zipPath, includeData: true);
+
+            using var archive = ZipFile.OpenRead(zipPath);
+            Assert.Equal(3, archive.Entries.Count); // 2 files + manifest
+
+            // All entry names must be distinct (case-insensitive).
+            var names = archive.Entries.Select(e => e.FullName).ToList();
+            Assert.Equal(names.Count, names.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+        }
+        finally
+        {
+            TryDelete(zipPath);
+            TryDeleteDirectory(dir1);
+            TryDeleteDirectory(dir2);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+    private static void TryDelete(params string[] paths)
+    {
+        foreach (var p in paths)
+        {
+            try { if (File.Exists(p)) File.Delete(p); } catch { /* best-effort */ }
+        }
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try { if (Directory.Exists(path)) Directory.Delete(path, recursive: true); } catch { /* best-effort */ }
+    }
+}

--- a/tests/Census.Tests/Census.Tests.csproj
+++ b/tests/Census.Tests/Census.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Census.Archive\Census.Archive.csproj" />
     <ProjectReference Include="..\..\src\Census.Domain\Census.Domain.csproj" />
     <ProjectReference Include="..\..\src\Census.Import\Census.Import.csproj" />
     <ProjectReference Include="..\..\src\Census.Storage\Census.Storage.csproj" />

--- a/tests/Census.Tests/Census.Tests.csproj
+++ b/tests/Census.Tests/Census.Tests.csproj
@@ -24,4 +24,10 @@
     </PackageReference>
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="fixtures\**\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/tests/Census.Tests/Census.Tests.csproj
+++ b/tests/Census.Tests/Census.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Census.Archive\Census.Archive.csproj" />
+    <ProjectReference Include="..\..\src\Census.ExternalTools\Census.ExternalTools.csproj" />
     <ProjectReference Include="..\..\src\Census.Domain\Census.Domain.csproj" />
     <ProjectReference Include="..\..\src\Census.Import\Census.Import.csproj" />
     <ProjectReference Include="..\..\src\Census.Storage\Census.Storage.csproj" />

--- a/tests/Census.Tests/CsvReportWriterTests.cs
+++ b/tests/Census.Tests/CsvReportWriterTests.cs
@@ -1,0 +1,202 @@
+using System.Globalization;
+using Census.Domain;
+using Census.Reports;
+using Xunit;
+
+namespace Census.Tests;
+
+public class CsvReportWriterTests
+{
+    private static readonly CsvReportWriter Writer = new();
+
+    // -----------------------------------------------------------------------
+    // Test 1: header row is present and correct
+    // -----------------------------------------------------------------------
+    [Fact]
+    public void Render_SingleEstimation_HeaderRowPresent()
+    {
+        var run = new Run
+        {
+            RunNo = "1",
+            Estimations = [new Estimation { Number = 1 }],
+        };
+
+        string csv = Writer.Render(run);
+        string firstLine = csv.Split('\n')[0];
+
+        Assert.Equal("RunNo,EstNo,Method,OFV,Kind,Index,Label,Estimate,SE,RSE_Pct,CI_Lower,CI_Upper,Shrinkage_Pct", firstLine);
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 2: theta row values
+    // -----------------------------------------------------------------------
+    [Fact]
+    public void Render_SingleEstimation_ThetaRowValues()
+    {
+        var run = new Run
+        {
+            RunNo = "27",
+            Estimations =
+            [
+                new Estimation
+                {
+                    Number = 1,
+                    Method = "FOCEI",
+                    Ofv = -1234.567,
+                    Parameters =
+                    [
+                        new Parameter
+                        {
+                            Kind = ParameterKind.Theta,
+                            Index = 1,
+                            Label = "CL",
+                            Estimate = 3.21,
+                            StandardError = 0.05,
+                        },
+                    ],
+                },
+            ],
+        };
+
+        string csv = Writer.Render(run);
+        string[] lines = csv.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        // lines[0] = header, lines[1] = first data row
+        Assert.True(lines.Length >= 2, "Expected at least a header and one data row.");
+
+        string[] row = lines[1].Split(',');
+
+        const int iRunNo       = 0;
+        const int iEstNo       = 1;
+        const int iMethod      = 2;
+        const int iOfv         = 3;
+        const int iKind        = 4;
+        const int iIndex       = 5;
+        const int iLabel       = 6;
+        const int iEstimate    = 7;
+        const int iSe          = 8;
+        const int iRsePct      = 9;
+        const int iShrinkage   = 12;
+
+        Assert.Equal("27",    row[iRunNo]);
+        Assert.Equal("1",     row[iEstNo]);
+        Assert.Equal("FOCEI", row[iMethod]);
+        Assert.Equal("-1234.57", row[iOfv]);
+        Assert.Equal("THETA", row[iKind]);
+        Assert.Equal("1",     row[iIndex]);
+        Assert.Equal("CL",    row[iLabel]);
+        Assert.Equal("3.21",  row[iEstimate]);
+        Assert.Equal("0.05",  row[iSe]);
+
+        // RSE should parse as a positive number
+        Assert.True(double.Parse(row[iRsePct], CultureInfo.InvariantCulture) > 0,
+            $"RSE_Pct should be positive, got '{row[iRsePct]}'");
+
+        // Theta has no shrinkage
+        Assert.Equal(string.Empty, row[iShrinkage]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 3: omega with shrinkage populates Shrinkage_Pct column
+    // -----------------------------------------------------------------------
+    [Fact]
+    public void Render_OmegaWithShrinkage_ShrinkageColumnPopulated()
+    {
+        var run = new Run
+        {
+            RunNo = "1",
+            Estimations =
+            [
+                new Estimation
+                {
+                    Number = 1,
+                    Parameters =
+                    [
+                        new Parameter
+                        {
+                            Kind = ParameterKind.Omega,
+                            Index = 1,
+                            Estimate = 0.04,
+                            Shrinkage = 12.3,
+                        },
+                    ],
+                },
+            ],
+        };
+
+        string csv = Writer.Render(run);
+        string[] lines = csv.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.True(lines.Length >= 2);
+
+        string[] row = lines[1].Split(',');
+        const int iShrinkage = 12;
+
+        Assert.False(string.IsNullOrEmpty(row[iShrinkage]),
+            "Shrinkage_Pct should be non-empty for an omega with shrinkage.");
+
+        double shrinkageValue = double.Parse(row[iShrinkage], CultureInfo.InvariantCulture);
+        Assert.Equal(12.3, shrinkageValue, precision: 4);
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 4: run with no estimations produces header only
+    // -----------------------------------------------------------------------
+    [Fact]
+    public void Render_NoEstimations_HeaderOnly()
+    {
+        var run = new Run { RunNo = "1" };
+
+        string csv = Writer.Render(run);
+
+        // Strip trailing whitespace/newlines before splitting
+        string[] lines = csv.Trim().Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.Single(lines);
+        Assert.StartsWith("RunNo,", lines[0]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 5: null SE → RSE_Pct, CI_Lower, CI_Upper are empty
+    // -----------------------------------------------------------------------
+    [Fact]
+    public void Render_NullSE_RseAndCiAreEmpty()
+    {
+        var run = new Run
+        {
+            RunNo = "1",
+            Estimations =
+            [
+                new Estimation
+                {
+                    Number = 1,
+                    Parameters =
+                    [
+                        new Parameter
+                        {
+                            Kind = ParameterKind.Theta,
+                            Index = 1,
+                            Estimate = 5.0,
+                            StandardError = null,
+                        },
+                    ],
+                },
+            ],
+        };
+
+        string csv = Writer.Render(run);
+        string[] lines = csv.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.True(lines.Length >= 2);
+
+        string[] row = lines[1].Split(',');
+
+        const int iRsePct  = 9;
+        const int iCiLower = 10;
+        const int iCiUpper = 11;
+
+        Assert.Equal(string.Empty, row[iRsePct]);
+        Assert.Equal(string.Empty, row[iCiLower]);
+        Assert.Equal(string.Empty, row[iCiUpper]);
+    }
+}

--- a/tests/Census.Tests/ExternalToolRunnerTests.cs
+++ b/tests/Census.Tests/ExternalToolRunnerTests.cs
@@ -1,0 +1,50 @@
+using System.Runtime.InteropServices;
+using Census.ExternalTools;
+
+namespace Census.Tests;
+
+public sealed class ExternalToolRunnerTests
+{
+    private readonly ProcessRunner _runner = new();
+
+    [Fact]
+    public void Run_EchoCommand_ReturnsZero()
+    {
+        int exitCode;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            exitCode = _runner.Run("cmd.exe", ["/c", "echo", "hello"]);
+        }
+        else
+        {
+            exitCode = _runner.Run("echo", ["hello"]);
+        }
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public void Run_InvalidExecutable_ThrowsException()
+    {
+        Assert.ThrowsAny<Exception>(() =>
+            _runner.Run("this_executable_does_not_exist_census_test", []));
+    }
+
+    [Fact]
+    public void Run_WithWorkingDirectory_Succeeds()
+    {
+        int exitCode;
+        string workingDirectory = AppContext.BaseDirectory;
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            exitCode = _runner.Run("cmd.exe", ["/c", "echo", "hello"], workingDirectory);
+        }
+        else
+        {
+            exitCode = _runner.Run("echo", ["hello"], workingDirectory);
+        }
+
+        Assert.Equal(0, exitCode);
+    }
+}

--- a/tests/Census.Tests/HtmlReportWriterTests.Render_SingleEstimation_MatchesSnapshot.verified.txt
+++ b/tests/Census.Tests/HtmlReportWriterTests.Render_SingleEstimation_MatchesSnapshot.verified.txt
@@ -1,0 +1,80 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Census Run Report &#8211; 27</title>
+  <style>
+    body { font-family: Arial, sans-serif; font-size: 11pt; margin: 2cm; }
+    table { border-collapse: collapse; width: 100%; margin-bottom: 1em; }
+    th, td { border: 1px solid #888; padding: 4px 8px; text-align: left; }
+    th { background: #dde; }
+    .section-theta td:first-child { font-style: italic; }
+    caption { text-align: left; font-weight: bold; margin-bottom: 4px; }
+  </style>
+</head>
+<body>
+<h1>Run 27</h1>
+<p>Observations: 1234, Individuals: 56</p>
+
+
+<h2>Estimation 1 (FOCEI)</h2>
+<p>OFV: -1234.57, Condition number: 20</p>
+
+
+<ul></ul>
+
+
+<table>
+  <thead>
+    <tr>
+      <th>No.</th><th>Parameter</th><th>Estimate</th><th>S.E.</th>
+      <th>%RSE</th><th>95% CI</th><th>Shrinkage&nbsp;(%)</th>
+    </tr>
+  </thead>
+  <tbody>
+  
+      <tr>
+        <td>THETA1</td>
+        <td>CL</td>
+        <td>3.21</td>
+        <td>0.05</td>
+        <td>1.558</td>
+        <td>3.112&nbsp;&#8211;&nbsp;3.308</td>
+        <td></td>
+      </tr>
+    
+      <tr>
+        <td>THETA2</td>
+        <td>V</td>
+        <td>15.4</td>
+        <td>0.8</td>
+        <td>5.195</td>
+        <td>13.83&nbsp;&#8211;&nbsp;16.97</td>
+        <td></td>
+      </tr>
+    
+      <tr>
+        <td>OMEGA1</td>
+        <td></td>
+        <td>0.09</td>
+        <td>0.01</td>
+        <td>11.11</td>
+        <td>0.0704&nbsp;&#8211;&nbsp;0.1096</td>
+        <td>12.3</td>
+      </tr>
+    
+      <tr>
+        <td>SIGMA1</td>
+        <td></td>
+        <td>0.04</td>
+        <td>0.005</td>
+        <td>12.5</td>
+        <td>0.0302&nbsp;&#8211;&nbsp;0.0498</td>
+        <td>5.6</td>
+      </tr>
+    
+  </tbody>
+</table>
+
+</body>
+</html>

--- a/tests/Census.Tests/HtmlReportWriterTests.cs
+++ b/tests/Census.Tests/HtmlReportWriterTests.cs
@@ -1,0 +1,60 @@
+using Census.Domain;
+using Census.Reports;
+using VerifyXunit;
+using Xunit;
+
+namespace Census.Tests;
+
+public sealed class HtmlReportWriterTests : VerifyBase
+{
+    public HtmlReportWriterTests() : base()
+    {
+    }
+
+    private static Run MakeRun() => new Run
+    {
+        RunNo = "27",
+        ObsRecs = 1234,
+        Individuals = 56,
+        Estimations = [new Estimation
+        {
+            Number = 1,
+            Method = "FOCEI",
+            Ofv = -1234.567,
+            ConditionNumber = 20.0,
+            Parameters = [
+                new Parameter { Kind = ParameterKind.Theta, Index = 1, Label = "CL", Estimate = 3.21, StandardError = 0.05 },
+                new Parameter { Kind = ParameterKind.Theta, Index = 2, Label = "V",  Estimate = 15.4, StandardError = 0.80 },
+                new Parameter { Kind = ParameterKind.Omega, Index = 1, Estimate = 0.09, StandardError = 0.01, Shrinkage = 12.3 },
+                new Parameter { Kind = ParameterKind.Sigma, Index = 1, Estimate = 0.04, StandardError = 0.005, Shrinkage = 5.6 },
+            ],
+        }],
+    };
+
+    [Fact]
+    public Task Render_SingleEstimation_MatchesSnapshot()
+    {
+        var result = new HtmlReportWriter().Render(MakeRun());
+        return Verify(result);
+    }
+
+    [Fact]
+    public void Render_ContainsKeyValues()
+    {
+        var result = new HtmlReportWriter().Render(MakeRun());
+        Assert.Contains("Run 27", result);
+        Assert.Contains("FOCEI", result);
+        Assert.Contains("CL", result);
+        Assert.Contains("3.21", result);
+        Assert.Contains("12.3", result); // shrinkage
+    }
+
+    [Fact]
+    public void Render_EmptyEstimations_ProducesValidHtml()
+    {
+        var run = new Run { RunNo = "99", Estimations = [] };
+        var result = new HtmlReportWriter().Render(run);
+        Assert.Contains("<!DOCTYPE html>", result);
+        Assert.Contains("Run 99", result);
+    }
+}

--- a/tests/Census.Tests/LatexReportWriterTests.Render_SingleEstimation_MatchesSnapshot.verified.txt
+++ b/tests/Census.Tests/LatexReportWriterTests.Render_SingleEstimation_MatchesSnapshot.verified.txt
@@ -1,0 +1,32 @@
+﻿\documentclass[12pt]{article}
+\usepackage[margin=2cm]{geometry}
+\usepackage{longtable}
+\usepackage{booktabs}
+\begin{document}
+
+\section*{Run 27}
+Observations: 1234, Individuals: 56\\
+
+
+\subsection*{Estimation 1 (FOCEI)}
+OFV: -1234.57, Condition number: 20\\
+
+
+\begin{itemize}
+\end{itemize}
+
+
+\begin{longtable}{llrrrrl}
+\toprule
+No. & Parameter & Estimate & S.E. & \%RSE & 95\% CI & Shrinkage (\%) \\
+\midrule
+\endhead
+THETA1 & CL & 3.21 & 0.05 & 1.558 & 3.112--3.308 &  \\
+THETA2 & V & 15.4 & 0.8 & 5.195 & 13.83--16.97 &  \\
+OMEGA1 &  & 0.09 & 0.01 & 11.11 & 0.0704--0.1096 & 12.3 \\
+SIGMA1 &  & 0.04 & 0.005 & 12.5 & 0.0302--0.0498 & 5.6 \\
+\bottomrule
+\end{longtable}
+
+
+\end{document}

--- a/tests/Census.Tests/LatexReportWriterTests.cs
+++ b/tests/Census.Tests/LatexReportWriterTests.cs
@@ -1,0 +1,79 @@
+using Census.Domain;
+using Census.Reports;
+using VerifyXunit;
+using Xunit;
+
+namespace Census.Tests;
+
+public sealed class LatexReportWriterTests : VerifyBase
+{
+    public LatexReportWriterTests() : base()
+    {
+    }
+
+    private static Run MakeRun() => new Run
+    {
+        RunNo = "27",
+        ObsRecs = 1234,
+        Individuals = 56,
+        Estimations = [new Estimation
+        {
+            Number = 1,
+            Method = "FOCEI",
+            Ofv = -1234.567,
+            ConditionNumber = 20.0,
+            Parameters = [
+                new Parameter { Kind = ParameterKind.Theta, Index = 1, Label = "CL", Estimate = 3.21, StandardError = 0.05 },
+                new Parameter { Kind = ParameterKind.Theta, Index = 2, Label = "V",  Estimate = 15.4, StandardError = 0.80 },
+                new Parameter { Kind = ParameterKind.Omega, Index = 1, Estimate = 0.09, StandardError = 0.01, Shrinkage = 12.3 },
+                new Parameter { Kind = ParameterKind.Sigma, Index = 1, Estimate = 0.04, StandardError = 0.005, Shrinkage = 5.6 },
+            ],
+        }],
+    };
+
+    [Fact]
+    public Task Render_SingleEstimation_MatchesSnapshot()
+    {
+        var result = new LatexReportWriter().Render(MakeRun());
+        return Verify(result);
+    }
+
+    [Fact]
+    public void Render_ContainsKeyValues()
+    {
+        var result = new LatexReportWriter().Render(MakeRun());
+        Assert.Contains(@"\section*{Run 27}", result);
+        Assert.Contains("FOCEI", result);
+        Assert.Contains("CL", result);
+        Assert.Contains("3.21", result);
+        Assert.Contains("12.3", result); // shrinkage
+    }
+
+    [Fact]
+    public void Render_LatexEscapesSpecialChars()
+    {
+        var run = new Run
+        {
+            RunNo = "run_27",
+            Estimations = [new Estimation
+            {
+                Number = 1,
+                Parameters = [
+                    new Parameter { Kind = ParameterKind.Theta, Index = 1, Label = "CL%50", Estimate = 1.0, StandardError = 0.1 },
+                ],
+            }],
+        };
+        var result = new LatexReportWriter().Render(run);
+        Assert.Contains(@"run\_27", result);
+        Assert.Contains(@"CL\%50", result);
+    }
+
+    [Fact]
+    public void Render_EmptyEstimations_ProducesDocument()
+    {
+        var run = new Run { RunNo = "99", Estimations = [] };
+        var result = new LatexReportWriter().Render(run);
+        Assert.Contains(@"\documentclass", result);
+        Assert.Contains(@"\end{document}", result);
+    }
+}

--- a/tests/Census.Tests/NonmemXmlImporterTests.cs
+++ b/tests/Census.Tests/NonmemXmlImporterTests.cs
@@ -229,6 +229,53 @@ public sealed class NonmemXmlImporterTests
     }
 
     [Fact]
+    public void Import_InlineXml_CapturesTimingsAndProblemTitleComment()
+    {
+        var xml = """
+            <?xml version="1.0"?>
+            <output>
+              <start_datetime>2024-01-15T10:30:00</start_datetime>
+              <control_stream></control_stream>
+              <nmtran></nmtran>
+              <nonmem version="7.4.4">
+                <license_information></license_information>
+                <program_information></program_information>
+                <problem number="1" subproblem="0" superproblem1="0" iteration1="0" superproblem2="0" iteration2="0">
+                  <problem_title>One-compartment base model</problem_title>
+                  <problem_information></problem_information>
+                  <estimation number="1" type="1">
+                    <estimation_method>FOCEI</estimation_method>
+                    <termination_status>0</termination_status>
+                    <final_objective_function>-500.0</final_objective_function>
+                    <estimation_elapsed_time>123.4</estimation_elapsed_time>
+                    <covariance_elapsed_time>45.6</covariance_elapsed_time>
+                  </estimation>
+                  <post_process_times>
+                    <post_elapsed_time>1.5</post_elapsed_time>
+                    <finaloutput_elapsed_time>0.7</finaloutput_elapsed_time>
+                  </post_process_times>
+                </problem>
+              </nonmem>
+              <stop_datetime>2024-01-15T10:45:00</stop_datetime>
+              <total_cputime>900.0</total_cputime>
+            </output>
+            """;
+
+        var run = new NonmemXmlImporter().ImportXml(xml, sourcePath: "run9.xml");
+
+        Assert.Equal("One-compartment base model", run.Comment);
+        Assert.Equal("2024-01-15T10:30:00", run.StartDateTime);
+        Assert.Equal("2024-01-15T10:45:00", run.StopDateTime);
+        Assert.Equal(900.0, run.TotalCpuTime!.Value, precision: 3);
+        Assert.Equal(1.5, run.PostElapsedTime!.Value, precision: 3);
+        Assert.Equal(0.7, run.FinalOutputElapsedTime!.Value, precision: 3);
+
+        var est = Assert.Single(run.Estimations);
+        Assert.Equal(123.4, est.EstimationTime!.Value, precision: 3);
+        Assert.Equal(45.6, est.CovarianceTime!.Value, precision: 3);
+    }
+
+    [Fact]
     public void Import_InlineXml_FlatShrinkageRowFormat()
     {
         // NM 7.3–7.5 write shrinkage as one SUBPOP row with one col per eta,

--- a/tests/Census.Tests/NonmemXmlImporterTests.cs
+++ b/tests/Census.Tests/NonmemXmlImporterTests.cs
@@ -227,4 +227,61 @@ public sealed class NonmemXmlImporterTests
         Assert.Empty(run.Estimations);
         Assert.Equal("1", run.RunNo);
     }
+
+    [Fact]
+    public void Import_InlineXml_FlatShrinkageRowFormat()
+    {
+        // NM 7.3–7.5 write shrinkage as one SUBPOP row with one col per eta,
+        // not one row per eta. Both etas must get their shrinkage values.
+        var xml = """
+            <?xml version="1.0" encoding="ASCII"?>
+            <nm:output xmlns:nm="http://namespaces.oreilly.com/xmlnut/address">
+              <nm:nonmem nm:version='7.3.0'>
+                <nm:problem nm:number='1'>
+                  <nm:estimation nm:number='1' nm:type='0'>
+                    <nm:estimation_method>focei</nm:estimation_method>
+                    <nm:termination_status>0</nm:termination_status>
+                    <nm:etashrink>
+                      <nm:row nm:rname='SUBPOP1'>
+                        <nm:col nm:cname='ETA1'>1.37</nm:col>
+                        <nm:col nm:cname='ETA2'>1.46</nm:col>
+                      </nm:row>
+                    </nm:etashrink>
+                    <nm:epsshrink>
+                      <nm:row nm:rname='SUBPOP1'>
+                        <nm:col nm:cname='EPS1'>5.22</nm:col>
+                      </nm:row>
+                    </nm:epsshrink>
+                    <nm:final_objective_function>-4126.11</nm:final_objective_function>
+                    <nm:omega>
+                      <nm:row nm:rname='1'>
+                        <nm:col nm:cname='1'>0.0716</nm:col>
+                      </nm:row>
+                      <nm:row nm:rname='2'>
+                        <nm:col nm:cname='1'>0.0</nm:col>
+                        <nm:col nm:cname='2'>0.0922</nm:col>
+                      </nm:row>
+                    </nm:omega>
+                    <nm:sigma>
+                      <nm:row nm:rname='1'>
+                        <nm:col nm:cname='1'>1.0</nm:col>
+                      </nm:row>
+                    </nm:sigma>
+                  </nm:estimation>
+                </nm:problem>
+              </nm:nonmem>
+            </nm:output>
+            """;
+
+        var run = new NonmemXmlImporter().ImportXml(xml, sourcePath: "runR001.xml");
+        var est = Assert.Single(run.Estimations);
+
+        var omegas = est.Parameters.Where(p => p.Kind == ParameterKind.Omega).ToList();
+        Assert.Equal(2, omegas.Count);
+        Assert.Equal(1.37, omegas[0].Shrinkage!.Value, precision: 2);
+        Assert.Equal(1.46, omegas[1].Shrinkage!.Value, precision: 2);
+
+        var sigma = Assert.Single(est.Parameters, p => p.Kind == ParameterKind.Sigma);
+        Assert.Equal(5.22, sigma.Shrinkage!.Value, precision: 2);
+    }
 }

--- a/tests/Census.Tests/NonmemXmlImporterTests.cs
+++ b/tests/Census.Tests/NonmemXmlImporterTests.cs
@@ -1,0 +1,230 @@
+using Census.Domain;
+using Census.Import;
+using Xunit;
+
+namespace Census.Tests;
+
+public sealed class NonmemXmlImporterTests
+{
+    private static string FixturePath(string name) =>
+        Path.Combine(AppContext.BaseDirectory, "fixtures", name);
+
+    [Fact]
+    public void CanImport_ReturnsTrueForXmlExtension()
+    {
+        Assert.True(new NonmemXmlImporter().CanImport("run27.xml"));
+        Assert.True(new NonmemXmlImporter().CanImport("RUN27.XML"));
+        Assert.False(new NonmemXmlImporter().CanImport("run27.lst"));
+    }
+
+    [Fact]
+    public void Import_Fixture_ExtractsRunNo()
+    {
+        var run = new NonmemXmlImporter().Import(FixturePath("run27.xml"));
+
+        Assert.Equal("27", run.RunNo);
+        Assert.Equal(27, run.IRunNo);
+    }
+
+    [Fact]
+    public void Import_Fixture_ExtractsObsRecsAndIndividuals()
+    {
+        var run = new NonmemXmlImporter().Import(FixturePath("run27.xml"));
+
+        Assert.Equal(1234, run.ObsRecs);
+        Assert.Equal(56, run.Individuals);
+    }
+
+    [Fact]
+    public void Import_Fixture_ExtractsEstimationMethod()
+    {
+        var run = new NonmemXmlImporter().Import(FixturePath("run27.xml"));
+
+        var est = Assert.Single(run.Estimations);
+        Assert.Equal(1, est.Number);
+        Assert.Equal("FOCEI", est.Method);
+    }
+
+    [Fact]
+    public void Import_Fixture_ExtractsOfv()
+    {
+        var run = new NonmemXmlImporter().Import(FixturePath("run27.xml"));
+
+        var est = Assert.Single(run.Estimations);
+        Assert.Equal(-1234.567, est.Ofv!.Value, precision: 3);
+    }
+
+    [Fact]
+    public void Import_Fixture_ExtractsThetaParameters()
+    {
+        var run = new NonmemXmlImporter().Import(FixturePath("run27.xml"));
+        var params_ = run.Estimations[0].Parameters;
+
+        var thetas = params_.Where(p => p.Kind == ParameterKind.Theta).ToList();
+        Assert.Equal(2, thetas.Count);
+
+        Assert.Equal(1, thetas[0].Index);
+        Assert.Equal("CL", thetas[0].Label);
+        Assert.Equal(3.21, thetas[0].Estimate!.Value, precision: 3);
+        Assert.Equal(0.05, thetas[0].StandardError!.Value, precision: 3);
+
+        Assert.Equal(2, thetas[1].Index);
+        Assert.Equal("V", thetas[1].Label);
+        Assert.Equal(15.4, thetas[1].Estimate!.Value, precision: 3);
+        Assert.Equal(0.80, thetas[1].StandardError!.Value, precision: 3);
+    }
+
+    [Fact]
+    public void Import_Fixture_ExtractsOmegaWithShrinkage()
+    {
+        var run = new NonmemXmlImporter().Import(FixturePath("run27.xml"));
+        var omega = Assert.Single(run.Estimations[0].Parameters, p => p.Kind == ParameterKind.Omega);
+
+        Assert.Equal(1, omega.Index);
+        Assert.Equal(0.09, omega.Estimate!.Value, precision: 3);
+        Assert.Equal(0.01, omega.StandardError!.Value, precision: 3);
+        Assert.Equal(12.3, omega.Shrinkage!.Value, precision: 2);
+    }
+
+    [Fact]
+    public void Import_Fixture_ExtractsSigmaWithShrinkage()
+    {
+        var run = new NonmemXmlImporter().Import(FixturePath("run27.xml"));
+        var sigma = Assert.Single(run.Estimations[0].Parameters, p => p.Kind == ParameterKind.Sigma);
+
+        Assert.Equal(1, sigma.Index);
+        Assert.Equal(0.04, sigma.Estimate!.Value, precision: 3);
+        Assert.Equal(0.005, sigma.StandardError!.Value, precision: 3);
+        Assert.Equal(5.6, sigma.Shrinkage!.Value, precision: 2);
+    }
+
+    [Fact]
+    public void Import_Fixture_ExtractsConditionNumber()
+    {
+        var run = new NonmemXmlImporter().Import(FixturePath("run27.xml"));
+        var est = run.Estimations[0];
+
+        Assert.Equal(20.0, est.ConditionNumber!.Value, precision: 2); // 30.0 / 1.5
+    }
+
+    [Fact]
+    public void Import_Fixture_NoWarningsOnSuccess()
+    {
+        var run = new NonmemXmlImporter().Import(FixturePath("run27.xml"));
+        Assert.Empty(run.Estimations[0].Warnings);
+    }
+
+    [Fact]
+    public void Import_Fixture_AddsXmlFileArtifactWithMd5()
+    {
+        var path = FixturePath("run27.xml");
+        var run = new NonmemXmlImporter().Import(path);
+
+        var artifact = Assert.Single(run.Files);
+        Assert.Equal("output", artifact.Role);
+        Assert.Equal(path, artifact.Path);
+        Assert.NotNull(artifact.Md5);
+        Assert.Equal(32, artifact.Md5!.Length); // hex MD5 is 32 chars
+    }
+
+    [Fact]
+    public void Import_InlineXml_CapturesTerminationWarning()
+    {
+        var xml = """
+            <?xml version="1.0"?>
+            <output>
+              <start_datetime>2024-01-15T10:30:00</start_datetime>
+              <control_stream></control_stream>
+              <nmtran></nmtran>
+              <nonmem version="7.4.4">
+                <license_information></license_information>
+                <program_information></program_information>
+                <problem number="1" subproblem="0" superproblem1="0" iteration1="0" superproblem2="0" iteration2="0">
+                  <problem_title></problem_title>
+                  <problem_information></problem_information>
+                  <estimation number="1" type="1">
+                    <estimation_method>FOCEI</estimation_method>
+                    <termination_status>1</termination_status>
+                    <termination_information>MINIMIZATION TERMINATED</termination_information>
+                    <final_objective_function>-500.0</final_objective_function>
+                  </estimation>
+                </problem>
+              </nonmem>
+              <stop_datetime>2024-01-15T10:35:00</stop_datetime>
+            </output>
+            """;
+
+        var run = new NonmemXmlImporter().ImportXml(xml, sourcePath: "run5.xml");
+        var est = Assert.Single(run.Estimations);
+        Assert.Equal("MINIMIZATION TERMINATED", Assert.Single(est.Warnings));
+    }
+
+    [Fact]
+    public void Import_InlineXml_LegacyEtashrinkFallback()
+    {
+        // NONMEM 7.2-era files use "etashrink"/"epsshrink" instead of "etashrinksd"/"epsshrinksd".
+        var xml = """
+            <?xml version="1.0"?>
+            <output>
+              <start_datetime>2024-01-15T10:30:00</start_datetime>
+              <control_stream></control_stream>
+              <nmtran></nmtran>
+              <nonmem version="7.2.0">
+                <license_information></license_information>
+                <program_information></program_information>
+                <problem number="1" subproblem="0" superproblem1="0" iteration1="0" superproblem2="0" iteration2="0">
+                  <problem_title></problem_title>
+                  <problem_information></problem_information>
+                  <estimation number="1" type="1">
+                    <estimation_method>FOCE</estimation_method>
+                    <termination_status>0</termination_status>
+                    <etashrink>
+                      <row rname="ETA(1)">
+                        <col cname="ETA(1)">8.5</col>
+                      </row>
+                    </etashrink>
+                    <final_objective_function>-800.0</final_objective_function>
+                    <omega>
+                      <row rname="ETA(1)">
+                        <col cname="ETA(1)">0.05</col>
+                      </row>
+                    </omega>
+                  </estimation>
+                </problem>
+              </nonmem>
+              <stop_datetime>2024-01-15T10:35:00</stop_datetime>
+            </output>
+            """;
+
+        var run = new NonmemXmlImporter().ImportXml(xml, sourcePath: "run3.xml");
+        var omega = Assert.Single(run.Estimations[0].Parameters, p => p.Kind == ParameterKind.Omega);
+        Assert.Equal(8.5, omega.Shrinkage!.Value, precision: 2);
+    }
+
+    [Fact]
+    public void Import_InlineXml_SimulationRunHasNoEstimations()
+    {
+        var xml = """
+            <?xml version="1.0"?>
+            <output>
+              <start_datetime>2024-01-15T10:30:00</start_datetime>
+              <control_stream></control_stream>
+              <nmtran></nmtran>
+              <nonmem version="7.4.4">
+                <license_information></license_information>
+                <program_information></program_information>
+                <problem number="1" subproblem="0" superproblem1="0" iteration1="0" superproblem2="0" iteration2="0">
+                  <problem_title></problem_title>
+                  <problem_information></problem_information>
+                  <simulation_information>SIMULATION</simulation_information>
+                </problem>
+              </nonmem>
+              <stop_datetime>2024-01-15T10:35:00</stop_datetime>
+            </output>
+            """;
+
+        var run = new NonmemXmlImporter().ImportXml(xml, sourcePath: "sim1.xml");
+        Assert.Empty(run.Estimations);
+        Assert.Equal("1", run.RunNo);
+    }
+}

--- a/tests/Census.Tests/NonmemXmlImporterTests.cs
+++ b/tests/Census.Tests/NonmemXmlImporterTests.cs
@@ -229,6 +229,42 @@ public sealed class NonmemXmlImporterTests
     }
 
     [Fact]
+    public void Import_InlineXml_ComputesConditionNumberFromCorrelationMatrix()
+    {
+        // NM 7.3-style output: no <eigenvalues>, covariance_status eigenvalues zeroed,
+        // but a <correlation> matrix is present. The 2x2 correlation matrix [[1,0.5],[0.5,1]]
+        // has eigenvalues 1.5 and 0.5, so the condition number is 3.0.
+        var xml = """
+            <?xml version="1.0" encoding="ASCII"?>
+            <nm:output xmlns:nm="http://namespaces.oreilly.com/xmlnut/address">
+              <nm:nonmem nm:version='7.3.0'>
+                <nm:problem nm:number='1'>
+                  <nm:estimation nm:number='1' nm:type='0'>
+                    <nm:estimation_method>focei</nm:estimation_method>
+                    <nm:termination_status>0</nm:termination_status>
+                    <nm:final_objective_function>-100.0</nm:final_objective_function>
+                    <nm:covariance_status nm:error='0' nm:numnegeigenvalues='-1' nm:mineigenvalue='0.0' nm:maxeigenvalue='0.0' nm:rms='0.0'/>
+                    <nm:correlation>
+                      <nm:row nm:rname='THETA1'>
+                        <nm:col nm:cname='THETA1'>0.10</nm:col>
+                      </nm:row>
+                      <nm:row nm:rname='THETA2'>
+                        <nm:col nm:cname='THETA1'>0.50</nm:col>
+                        <nm:col nm:cname='THETA2'>0.20</nm:col>
+                      </nm:row>
+                    </nm:correlation>
+                  </nm:estimation>
+                </nm:problem>
+              </nm:nonmem>
+            </nm:output>
+            """;
+
+        var run = new NonmemXmlImporter().ImportXml(xml, sourcePath: "runR010.xml");
+        var est = Assert.Single(run.Estimations);
+        Assert.Equal(3.0, est.ConditionNumber!.Value, precision: 6);
+    }
+
+    [Fact]
     public void Import_InlineXml_CapturesTimingsAndProblemTitleComment()
     {
         var xml = """

--- a/tests/Census.Tests/NonmemXmlImporterTests.cs
+++ b/tests/Census.Tests/NonmemXmlImporterTests.cs
@@ -265,6 +265,37 @@ public sealed class NonmemXmlImporterTests
     }
 
     [Fact]
+    public void Import_InlineXml_ConditionNumber_EquicorrelationMatrix3x3()
+    {
+        // A 3x3 correlation matrix with 1 on the diagonal and 0.5 off-diagonal has
+        // eigenvalues 1+(n-1)*rho = 2.0 and 1-rho = 0.5 (x2), so condition number = 4.0.
+        // (Diagonal values below are standard errors, which the importer replaces with 1.)
+        var xml = """
+            <?xml version="1.0" encoding="ASCII"?>
+            <nm:output xmlns:nm="http://namespaces.oreilly.com/xmlnut/address">
+              <nm:nonmem nm:version='7.3.0'>
+                <nm:problem nm:number='1'>
+                  <nm:estimation nm:number='1' nm:type='0'>
+                    <nm:estimation_method>focei</nm:estimation_method>
+                    <nm:termination_status>0</nm:termination_status>
+                    <nm:final_objective_function>-100.0</nm:final_objective_function>
+                    <nm:correlation>
+                      <nm:row nm:rname='T1'><nm:col nm:cname='T1'>0.10</nm:col></nm:row>
+                      <nm:row nm:rname='T2'><nm:col nm:cname='T1'>0.50</nm:col><nm:col nm:cname='T2'>0.20</nm:col></nm:row>
+                      <nm:row nm:rname='T3'><nm:col nm:cname='T1'>0.50</nm:col><nm:col nm:cname='T2'>0.50</nm:col><nm:col nm:cname='T3'>0.30</nm:col></nm:row>
+                    </nm:correlation>
+                  </nm:estimation>
+                </nm:problem>
+              </nm:nonmem>
+            </nm:output>
+            """;
+
+        var run = new NonmemXmlImporter().ImportXml(xml, sourcePath: "runR011.xml");
+        var est = Assert.Single(run.Estimations);
+        Assert.Equal(4.0, est.ConditionNumber!.Value, precision: 6);
+    }
+
+    [Fact]
     public void Import_InlineXml_CapturesTimingsAndProblemTitleComment()
     {
         var xml = """

--- a/tests/Census.Tests/RealWorldImporterTests.cs
+++ b/tests/Census.Tests/RealWorldImporterTests.cs
@@ -1,0 +1,97 @@
+using Census.Domain;
+using Census.Import;
+using Xunit;
+
+namespace Census.Tests;
+
+/// <summary>
+/// Validates the importer against real NONMEM XML output files from four version IQ packages.
+/// Tests are skipped if the reference directories are not present on this machine.
+/// </summary>
+public sealed class RealWorldImporterTests
+{
+    private static readonly string[] RefDirs =
+    [
+        @"C:\Users\justin\Downloads\NONMEM_tests\NONMEM730_IQ_160323\Reference",
+        @"C:\Users\justin\Downloads\NONMEM_tests\NONMEM743_IQ_180814\Reference",
+        @"C:\Users\justin\Downloads\NONMEM_tests\NONMEM750_IQ_210204\Reference",
+        @"C:\Users\justin\Downloads\NONMEM_tests\NONMEM760_IQ_250422\Reference",
+    ];
+
+    [Fact]
+    public void Import_AllRealFiles_NoExceptions()
+    {
+        var dirs = RefDirs.Where(Directory.Exists).ToList();
+        if (dirs.Count == 0) return;
+
+        var importer = new NonmemXmlImporter();
+        var failures = new List<string>();
+
+        foreach (var dir in dirs)
+        {
+            foreach (var file in Directory.EnumerateFiles(dir, "*.xml").OrderBy(f => f))
+            {
+                try
+                {
+                    var run = importer.Import(file);
+
+                    // Sanity-check the result structure.
+                    Assert.NotNull(run.RunNo);
+                    Assert.NotEmpty(run.RunNo);
+                    foreach (var est in run.Estimations)
+                    {
+                        Assert.NotNull(est.Method);
+                        Assert.True(est.Parameters.All(p => p.Estimate.HasValue || p.StandardError == null),
+                            $"{file}: parameter without estimate has a standard error");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    failures.Add($"{file}: {ex.GetType().Name}: {ex.Message}");
+                }
+            }
+        }
+
+        Assert.Empty(failures);
+    }
+
+    [Fact]
+    public void Import_AllRealFiles_ReportsKeyFields()
+    {
+        var dirs = RefDirs.Where(Directory.Exists).ToList();
+        if (dirs.Count == 0) return;
+
+        var importer = new NonmemXmlImporter();
+
+        // Count files where each optional field is populated, as a coverage check.
+        int total = 0, withObsRecs = 0, withIndividuals = 0;
+        int withEstimations = 0, withShrinkage = 0, withConditionNumber = 0;
+
+        foreach (var dir in dirs)
+        {
+            foreach (var file in Directory.EnumerateFiles(dir, "*.xml"))
+            {
+                var run = importer.Import(file);
+                total++;
+
+                if (run.ObsRecs.HasValue) withObsRecs++;
+                if (run.Individuals.HasValue) withIndividuals++;
+                if (run.Estimations.Count > 0) withEstimations++;
+
+                foreach (var est in run.Estimations)
+                {
+                    if (est.Parameters.Any(p => p.Shrinkage.HasValue)) withShrinkage++;
+                    if (est.ConditionNumber.HasValue) withConditionNumber++;
+                }
+            }
+        }
+
+        // At least half of all files should have estimations.
+        Assert.True(withEstimations >= total / 2,
+            $"Only {withEstimations}/{total} files had estimations");
+
+        // Most files with estimations should have shrinkage (real NONMEM output always includes it).
+        Assert.True(withShrinkage >= withEstimations / 2,
+            $"Only {withShrinkage}/{withEstimations} estimation files had shrinkage");
+    }
+}

--- a/tests/Census.Tests/RealWorldImporterTests.cs
+++ b/tests/Census.Tests/RealWorldImporterTests.cs
@@ -81,7 +81,13 @@ public sealed class RealWorldImporterTests
                 foreach (var est in run.Estimations)
                 {
                     if (est.Parameters.Any(p => p.Shrinkage.HasValue)) withShrinkage++;
-                    if (est.ConditionNumber.HasValue) withConditionNumber++;
+                    if (est.ConditionNumber.HasValue)
+                    {
+                        withConditionNumber++;
+                        // Computed condition numbers must be positive and finite.
+                        Assert.True(est.ConditionNumber.Value > 0 && double.IsFinite(est.ConditionNumber.Value),
+                            $"{file}: non-positive/non-finite condition number {est.ConditionNumber.Value}");
+                    }
                 }
             }
         }
@@ -93,5 +99,10 @@ public sealed class RealWorldImporterTests
         // Most files with estimations should have shrinkage (real NONMEM output always includes it).
         Assert.True(withShrinkage >= withEstimations / 2,
             $"Only {withShrinkage}/{withEstimations} estimation files had shrinkage");
+
+        // Condition numbers are now derived from the correlation matrix, so runs with a
+        // successful covariance step must populate them (previously always null on NM 7.3).
+        Assert.True(withConditionNumber > 0,
+            $"No files produced a condition number out of {withEstimations} with estimations");
     }
 }

--- a/tests/Census.Tests/RunTests.cs
+++ b/tests/Census.Tests/RunTests.cs
@@ -13,13 +13,12 @@ public class RunTests
             RunNo = "27",
             IRunNo = 27,
             ParentNo = "12",
-            Ofv = -1234.56,
         };
 
         Assert.Equal("27", run.RunNo);
         Assert.Equal(27, run.IRunNo);
         Assert.Equal("12", run.ParentNo);
-        Assert.Equal(-1234.56, run.Ofv);
-        Assert.Empty(run.Thetas);
+        Assert.Empty(run.Estimations);
+        Assert.Empty(run.Files);
     }
 }

--- a/tests/Census.Tests/SqliteProjectStoreTests.cs
+++ b/tests/Census.Tests/SqliteProjectStoreTests.cs
@@ -34,10 +34,18 @@ public sealed class SqliteProjectStoreTests : IDisposable
         Assert.Equal("run27.lst", artifact.Path);
         Assert.Equal("abc123", artifact.Md5);
 
+        Assert.Equal("2024-01-15T10:30:00", run.StartDateTime);
+        Assert.Equal("2024-01-15T10:45:00", run.StopDateTime);
+        Assert.Equal(900.0, run.TotalCpuTime);
+        Assert.Equal(1.5, run.PostElapsedTime);
+        Assert.Equal(0.7, run.FinalOutputElapsedTime);
+
         var est = Assert.Single(run.Estimations);
         Assert.Equal("FOCEI", est.Method);
         Assert.Equal(-1234.56, est.Ofv);
         Assert.Equal(12.3, est.ConditionNumber);
+        Assert.Equal(123.4, est.EstimationTime);
+        Assert.Equal(45.6, est.CovarianceTime);
         Assert.Equal("Rounding errors", Assert.Single(est.Warnings));
 
         Assert.Equal(2, est.Parameters.Count);
@@ -83,6 +91,11 @@ public sealed class SqliteProjectStoreTests : IDisposable
         KeyRun = true,
         ObsRecs = 1234,
         Individuals = 56,
+        StartDateTime = "2024-01-15T10:30:00",
+        StopDateTime = "2024-01-15T10:45:00",
+        TotalCpuTime = 900.0,
+        PostElapsedTime = 1.5,
+        FinalOutputElapsedTime = 0.7,
         Files = [new FileArtifact { Role = "output", Path = "run27.lst", Md5 = "abc123" }],
         Estimations =
         [
@@ -93,6 +106,8 @@ public sealed class SqliteProjectStoreTests : IDisposable
                 Ofv = -1234.56,
                 DOfv = -10.0,
                 ConditionNumber = 12.3,
+                EstimationTime = 123.4,
+                CovarianceTime = 45.6,
                 Warnings = ["Rounding errors"],
                 Parameters =
                 [

--- a/tests/Census.Tests/SqliteProjectStoreTests.cs
+++ b/tests/Census.Tests/SqliteProjectStoreTests.cs
@@ -1,0 +1,114 @@
+using Census.Domain;
+using Census.Storage;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace Census.Tests;
+
+public sealed class SqliteProjectStoreTests : IDisposable
+{
+    private readonly string _path = Path.Combine(
+        Path.GetTempPath(), $"census-test-{Guid.NewGuid():N}.cen");
+
+    [Fact]
+    public void Create_ThenSaveAndReload_RoundTripsRun()
+    {
+        var store = new SqliteProjectStore();
+        store.Create(_path);
+        store.SaveRun(SampleRun());
+
+        // Reopen with a fresh store to prove persistence, not in-memory state.
+        var reopened = new SqliteProjectStore();
+        reopened.Open(_path);
+        var runs = reopened.GetRuns();
+
+        var run = Assert.Single(runs);
+        Assert.Equal("27", run.RunNo);
+        Assert.Equal(27, run.IRunNo);
+        Assert.Equal("12", run.ParentNo);
+        Assert.True(run.KeyRun);
+        Assert.Equal(1234, run.ObsRecs);
+
+        var artifact = Assert.Single(run.Files);
+        Assert.Equal("output", artifact.Role);
+        Assert.Equal("run27.lst", artifact.Path);
+        Assert.Equal("abc123", artifact.Md5);
+
+        var est = Assert.Single(run.Estimations);
+        Assert.Equal("FOCEI", est.Method);
+        Assert.Equal(-1234.56, est.Ofv);
+        Assert.Equal(12.3, est.ConditionNumber);
+        Assert.Equal("Rounding errors", Assert.Single(est.Warnings));
+
+        Assert.Equal(2, est.Parameters.Count);
+        var theta = Assert.Single(est.Parameters, p => p.Kind == ParameterKind.Theta);
+        Assert.Equal(1, theta.Index);
+        Assert.Equal("CL", theta.Label);
+        Assert.Equal(3.21, theta.Estimate);
+        Assert.Equal(0.15, theta.StandardError);
+
+        var omega = Assert.Single(est.Parameters, p => p.Kind == ParameterKind.Omega);
+        Assert.Equal(0.42, omega.Shrinkage);
+    }
+
+    [Fact]
+    public void Open_AppliesMigrationsIdempotently()
+    {
+        new SqliteProjectStore().Create(_path);
+
+        // Opening again must not throw or duplicate schema.
+        var store = new SqliteProjectStore();
+        store.Open(_path);
+
+        Assert.Empty(store.GetRuns());
+        Assert.Equal(Migrator.LatestVersion(), AppliedSchemaVersion());
+    }
+
+    private long AppliedSchemaVersion()
+    {
+        using var connection = new SqliteConnection(
+            new SqliteConnectionStringBuilder { DataSource = _path }.ToString());
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT MAX(Version) FROM schema_version;";
+        return Convert.ToInt64(command.ExecuteScalar(), System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private static Run SampleRun() => new()
+    {
+        RunNo = "27",
+        IRunNo = 27,
+        ParentNo = "12",
+        Comment = "base model",
+        KeyRun = true,
+        ObsRecs = 1234,
+        Individuals = 56,
+        Files = [new FileArtifact { Role = "output", Path = "run27.lst", Md5 = "abc123" }],
+        Estimations =
+        [
+            new Estimation
+            {
+                Number = 1,
+                Method = "FOCEI",
+                Ofv = -1234.56,
+                DOfv = -10.0,
+                ConditionNumber = 12.3,
+                Warnings = ["Rounding errors"],
+                Parameters =
+                [
+                    new Parameter { Kind = ParameterKind.Theta, Index = 1, Label = "CL", Estimate = 3.21, StandardError = 0.15 },
+                    new Parameter { Kind = ParameterKind.Omega, Index = 1, Label = "IIV-CL", Estimate = 0.09, StandardError = 0.02, Shrinkage = 0.42 },
+                ],
+            },
+        ],
+    };
+
+    public void Dispose()
+    {
+        SqliteConnection.ClearAllPools();
+        if (File.Exists(_path))
+        {
+            File.Delete(_path);
+        }
+    }
+}

--- a/tests/Census.Tests/fixtures/run27.xml
+++ b/tests/Census.Tests/fixtures/run27.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="ASCII"?>
+<nm:output xmlns:nm="http://namespaces.oreilly.com/xmlnut/address">
+  <nm:start_datetime>2024-01-15T10:30:00</nm:start_datetime>
+  <nm:control_stream>$PROB run27</nm:control_stream>
+  <nm:nmtran>SUCCESSFUL</nm:nmtran>
+  <nm:nonmem nm:version="7.6.0">
+    <nm:license_information>NONMEM 7.6.0</nm:license_information>
+    <nm:program_information>ICON plc</nm:program_information>
+    <nm:problem nm:number="1" nm:subproblem="0" nm:superproblem1="0" nm:iteration1="0" nm:superproblem2="0" nm:iteration2="0">
+      <nm:problem_title>$PROBLEM run27</nm:problem_title>
+      <nm:problem_information>NONMEM run 27</nm:problem_information>
+      <nm:problem_options nm:data_nobs="1234" nm:data_nind="56"/>
+      <nm:estimation nm:number="1" nm:type="1">
+        <nm:estimation_method>FOCEI</nm:estimation_method>
+        <nm:termination_status>0</nm:termination_status>
+        <nm:termination_information>MINIMIZATION SUCCESSFUL</nm:termination_information>
+        <nm:etashrinksd nm:number="1">
+          <nm:row nm:rname="ETA(1)">
+            <nm:col nm:cname="ETA(1)">12.3</nm:col>
+          </nm:row>
+        </nm:etashrinksd>
+        <nm:epsshrinksd nm:number="1">
+          <nm:row nm:rname="EPS(1)">
+            <nm:col nm:cname="EPS(1)">5.6</nm:col>
+          </nm:row>
+        </nm:epsshrinksd>
+        <nm:final_objective_function>-1234.567</nm:final_objective_function>
+        <nm:theta nm:number="1">
+          <nm:val nm:name="CL">3.21</nm:val>
+          <nm:val nm:name="V">15.4</nm:val>
+        </nm:theta>
+        <nm:omega nm:number="1">
+          <nm:row nm:rname="ETA(1)">
+            <nm:col nm:cname="ETA(1)">0.09</nm:col>
+          </nm:row>
+        </nm:omega>
+        <nm:sigma nm:number="1">
+          <nm:row nm:rname="EPS(1)">
+            <nm:col nm:cname="EPS(1)">0.04</nm:col>
+          </nm:row>
+        </nm:sigma>
+        <nm:thetase nm:number="1">
+          <nm:val nm:name="CL">0.05</nm:val>
+          <nm:val nm:name="V">0.80</nm:val>
+        </nm:thetase>
+        <nm:omegase nm:number="1">
+          <nm:row nm:rname="ETA(1)">
+            <nm:col nm:cname="ETA(1)">0.01</nm:col>
+          </nm:row>
+        </nm:omegase>
+        <nm:sigmase nm:number="1">
+          <nm:row nm:rname="EPS(1)">
+            <nm:col nm:cname="EPS(1)">0.005</nm:col>
+          </nm:row>
+        </nm:sigmase>
+        <nm:eigenvalues nm:number="1">
+          <nm:val nm:name="1">1.5</nm:val>
+          <nm:val nm:name="2">30.0</nm:val>
+        </nm:eigenvalues>
+        <nm:covariance_status nm:error="0" nm:numnegeigenvalues="0" nm:mineigenvalue="1.5" nm:maxeigenvalue="30.0" nm:rms="0.01"/>
+      </nm:estimation>
+    </nm:problem>
+  </nm:nonmem>
+  <nm:stop_datetime>2024-01-15T10:35:00</nm:stop_datetime>
+  <nm:total_cputime>12.34</nm:total_cputime>
+</nm:output>


### PR DESCRIPTION
## Summary

Builds out the .NET 10 / Avalonia port of Census across Phases 2–7: a clean domain model, SQLite storage, the NONMEM XML importer, report/export/archive, the CLI, the desktop UI replicating the original Census, and the release pipeline.

## What's included

**Domain & storage**
- Pure `Census.Domain` records (Run, Estimation, Parameter, FileArtifact).
- SQLite store via Dapper with versioned, idempotent migrations (`0001_initial`, `0002_timing`); cascade deletes; `DeleteRun`.

**Importer (`Census.Import`)**
- NONMEM 7.2+ XML, namespace-prefix tolerant; validated against 276 real reference files (NM 7.3/7.4/7.5/7.6).
- Theta/omega/sigma, SE, shrinkage (incl. flat SUBPOP1 layout), warnings.
- Run/estimation timings; `Comment` from `$PROBLEM` title.
- Condition number computed from the correlation matrix via a Jacobi eigensolver (NM 7.3 leaves the XML eigenvalue fields empty).

**Reports / archive / CLI**
- CSV (CsvHelper), HTML & LaTeX (Scriban) writers; ZIP archive with JSON manifest.
- `census` CLI: import, import-folder, export-run, compare, archive.

**Desktop UI (`Census.App`, Avalonia)**
- Three-pane layout matching the original: icon toolbar, left filter tree, run grid, and estimation grid + parameter tabs.
- Project management, recent files, run detail with theta/omega/sigma, import/export/archive/delete actions.
- Settings dialog incl. user-configurable grid font size; native Windows fonts; Light theme.

**Release pipeline**
- CI builds/tests on Windows/macOS/Linux; on tag, publishes self-contained single-file artifacts per RID, generates a GitHub Release with SHA-256 checksums. Code-signing stub in place (SignPath pending).

## Tests

43 xUnit tests pass (importer incl. real-file corpus, storage round-trip, condition-number eigensolver). Release build clean.

## Follow-ups (not in this PR)

- PsN import (placeholder tab).
- Legacy `.lst` listing parser (if needed).
- Compare/Diagnostics/Matrices views (currently stubs/placeholders).
- Code signing once SignPath is approved.
- Re-import existing projects to populate newly computed fields (timings, condition numbers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)