### PR TITLE
Compare view (selected runs) and covariance/correlation matrices

### DIFF
--- a/src/Census.App/ViewModels/CompareViewModel.cs
+++ b/src/Census.App/ViewModels/CompareViewModel.cs
@@ -1,0 +1,86 @@
+using System.Globalization;
+using Census.Domain;
+
+namespace Census.App.ViewModels;
+
+/// <summary>One comparison row: a label plus one cell value per run (column order).</summary>
+public sealed class CompareRowViewModel
+{
+    public CompareRowViewModel(string label, IReadOnlyList<string> values)
+    {
+        Label = label;
+        Values = values;
+    }
+
+    public string Label { get; }
+    public IReadOnlyList<string> Values { get; }
+}
+
+/// <summary>
+/// Side-by-side comparison of runs: OFV, dOFV and condition number, followed by every
+/// parameter (theta/omega/sigma) found across the runs. Columns are the runs (ordered by
+/// run number); the parameter columns are generated in the view from <see cref="RunHeaders"/>.
+/// </summary>
+public sealed class CompareViewModel
+{
+    public CompareViewModel(IReadOnlyList<Run> runs)
+    {
+        var ordered = runs.OrderBy(r => r.IRunNo).ToList();
+        RunHeaders = ordered.Select(r => r.RunNo).ToList();
+        var byNo = ordered.ToDictionary(r => r.RunNo, r => r);
+
+        static Estimation? Last(Run r) => r.Estimations.Count > 0 ? r.Estimations[^1] : null;
+
+        var rows = new List<CompareRowViewModel>
+        {
+            new("OFV", ordered.Select(r =>
+                Last(r)?.Ofv?.ToString("0.000", CultureInfo.InvariantCulture) ?? string.Empty).ToList()),
+
+            new("dOFV", ordered.Select(r =>
+            {
+                var est = Last(r);
+                if (r.ParentNo is not null && byNo.TryGetValue(r.ParentNo, out var parent)
+                    && est?.Ofv is double ofv && Last(parent)?.Ofv is double parentOfv)
+                {
+                    return (ofv - parentOfv).ToString("+0.000;-0.000;0.000", CultureInfo.InvariantCulture);
+                }
+                return string.Empty;
+            }).ToList()),
+
+            new("Condition no.", ordered.Select(r =>
+                Last(r)?.ConditionNumber?.ToString("0", CultureInfo.InvariantCulture) ?? string.Empty).ToList()),
+        };
+
+        // Union of parameters across all runs, ordered theta -> omega -> sigma by index.
+        var keys = ordered
+            .SelectMany(r => Last(r)?.Parameters ?? Enumerable.Empty<Parameter>())
+            .Select(p => (p.Kind, p.Index))
+            .Distinct()
+            .OrderBy(k => k.Kind)
+            .ThenBy(k => k.Index)
+            .ToList();
+
+        foreach (var (kind, index) in keys)
+        {
+            var label = ordered
+                .Select(r => Last(r)?.Parameters.FirstOrDefault(p => p.Kind == kind && p.Index == index)?.Label)
+                .FirstOrDefault(l => !string.IsNullOrEmpty(l));
+
+            var name = $"{kind.ToString().ToUpperInvariant()}{index}"
+                + (string.IsNullOrEmpty(label) ? string.Empty : $" ({label})");
+
+            var values = ordered.Select(r =>
+            {
+                var p = Last(r)?.Parameters.FirstOrDefault(pp => pp.Kind == kind && pp.Index == index);
+                return p?.Estimate?.ToString("G4", CultureInfo.InvariantCulture) ?? string.Empty;
+            }).ToList();
+
+            rows.Add(new CompareRowViewModel(name, values));
+        }
+
+        Rows = rows;
+    }
+
+    public IReadOnlyList<string> RunHeaders { get; }
+    public IReadOnlyList<CompareRowViewModel> Rows { get; }
+}

--- a/src/Census.App/ViewModels/CompareViewModel.cs
+++ b/src/Census.App/ViewModels/CompareViewModel.cs
@@ -25,26 +25,26 @@ public sealed class CompareViewModel
 {
     public CompareViewModel(IReadOnlyList<Run> runs)
     {
-        var ordered = runs.OrderBy(r => r.IRunNo).ToList();
+        // Preserve selection order: the first selected run is the first column and the
+        // reference against which every other run's dOFV is computed.
+        var ordered = runs.ToList();
         RunHeaders = ordered.Select(r => r.RunNo).ToList();
-        var byNo = ordered.ToDictionary(r => r.RunNo, r => r);
 
         static Estimation? Last(Run r) => r.Estimations.Count > 0 ? r.Estimations[^1] : null;
+
+        var referenceOfv = ordered.Count > 0 ? Last(ordered[0])?.Ofv : null;
 
         var rows = new List<CompareRowViewModel>
         {
             new("OFV", ordered.Select(r =>
                 Last(r)?.Ofv?.ToString("0.000", CultureInfo.InvariantCulture) ?? string.Empty).ToList()),
 
-            new("dOFV", ordered.Select(r =>
+            new("dOFV (vs first)", ordered.Select(r =>
             {
-                var est = Last(r);
-                if (r.ParentNo is not null && byNo.TryGetValue(r.ParentNo, out var parent)
-                    && est?.Ofv is double ofv && Last(parent)?.Ofv is double parentOfv)
-                {
-                    return (ofv - parentOfv).ToString("+0.000;-0.000;0.000", CultureInfo.InvariantCulture);
-                }
-                return string.Empty;
+                var ofv = Last(r)?.Ofv;
+                if (ofv is null || referenceOfv is null)
+                    return string.Empty;
+                return (ofv.Value - referenceOfv.Value).ToString("+0.000;-0.000;0.000", CultureInfo.InvariantCulture);
             }).ToList()),
 
             new("Condition no.", ordered.Select(r =>

--- a/src/Census.App/ViewModels/EstimationStepViewModel.cs
+++ b/src/Census.App/ViewModels/EstimationStepViewModel.cs
@@ -27,6 +27,9 @@ public sealed class EstimationStepViewModel
         Omegas = ps.Where(p => p.Kind == ParameterKind.Omega).Select(p => new ParameterRowViewModel(p)).ToList();
         Sigmas = ps.Where(p => p.Kind == ParameterKind.Sigma).Select(p => new ParameterRowViewModel(p)).ToList();
         Warnings = est.Warnings;
+
+        Correlation = est.Correlation is not null ? new MatrixViewModel(est.Correlation) : null;
+        Covariance = est.Covariance is not null ? new MatrixViewModel(est.Covariance) : null;
     }
 
     public string Step { get; }
@@ -42,6 +45,8 @@ public sealed class EstimationStepViewModel
     public IReadOnlyList<ParameterRowViewModel> Omegas { get; }
     public IReadOnlyList<ParameterRowViewModel> Sigmas { get; }
     public IReadOnlyList<string> Warnings { get; }
+    public MatrixViewModel? Correlation { get; }
+    public MatrixViewModel? Covariance { get; }
 
     internal static string FmtSeconds(double? v) =>
         v.HasValue ? v.Value.ToString("0.##", CultureInfo.InvariantCulture) : string.Empty;

--- a/src/Census.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Census.App/ViewModels/MainWindowViewModel.cs
@@ -178,13 +178,32 @@ public partial class MainWindowViewModel : ObservableObject
         UpdateStatusText($"Deleted run {runNo}.");
     }
 
-    [RelayCommand(CanExecute = nameof(IsProjectOpen))]
+    private readonly List<RunSummaryViewModel> _compareSelection = [];
+
+    public bool CanCompare => IsProjectOpen && _compareSelection.Count >= 2;
+
+    /// <summary>Receives the run grid's current multi-selection (called from the view).</summary>
+    public void SetCompareSelection(System.Collections.IList? items)
+    {
+        _compareSelection.Clear();
+        if (items is not null)
+        {
+            foreach (var item in items)
+            {
+                if (item is RunSummaryViewModel run)
+                    _compareSelection.Add(run);
+            }
+        }
+        CompareCommand.NotifyCanExecuteChanged();
+    }
+
+    [RelayCommand(CanExecute = nameof(CanCompare))]
     private async Task CompareAsync()
     {
-        var runs = _store.GetRuns();
-        if (runs.Count == 0)
+        var runs = _compareSelection.Select(r => r.Model).ToList();
+        if (runs.Count < 2)
         {
-            UpdateStatusText("No runs to compare.");
+            UpdateStatusText("Select two or more runs to compare (Ctrl/Shift-click).");
             return;
         }
 

--- a/src/Census.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Census.App/ViewModels/MainWindowViewModel.cs
@@ -179,8 +179,20 @@ public partial class MainWindowViewModel : ObservableObject
     }
 
     [RelayCommand(CanExecute = nameof(IsProjectOpen))]
-    private void Compare() =>
-        UpdateStatusText("Compare: use the run list to review runs side by side (full compare view is planned).");
+    private async Task CompareAsync()
+    {
+        var runs = _store.GetRuns();
+        if (runs.Count == 0)
+        {
+            UpdateStatusText("No runs to compare.");
+            return;
+        }
+
+        var win = new CompareWindow(new CompareViewModel(runs));
+        var owner = (Avalonia.Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.MainWindow;
+        if (owner is not null)
+            await win.ShowDialog(owner);
+    }
 
     [RelayCommand(CanExecute = nameof(IsRunSelected))]
     private void Diagnostics() =>

--- a/src/Census.App/ViewModels/MatrixViewModel.cs
+++ b/src/Census.App/ViewModels/MatrixViewModel.cs
@@ -1,0 +1,47 @@
+using System.Globalization;
+using Census.Domain;
+
+namespace Census.App.ViewModels;
+
+/// <summary>One matrix row: a label plus n formatted cell strings (blank above the diagonal).</summary>
+public sealed class MatrixRowViewModel
+{
+    public MatrixRowViewModel(string label, IReadOnlyList<string> cells)
+    {
+        Label = label;
+        Cells = cells;
+    }
+
+    public string Label { get; }
+    public IReadOnlyList<string> Cells { get; }
+}
+
+/// <summary>Display model for a labelled lower-triangular matrix (covariance/correlation).</summary>
+public sealed class MatrixViewModel
+{
+    public MatrixViewModel(NamedMatrix matrix)
+    {
+        ColumnHeaders = matrix.Labels.ToList();
+        var n = matrix.Labels.Count;
+
+        var rows = new List<MatrixRowViewModel>(n);
+        for (var i = 0; i < n; i++)
+        {
+            var rowVals = i < matrix.Values.Count ? matrix.Values[i] : [];
+            var cells = new List<string>(n);
+            for (var j = 0; j < n; j++)
+            {
+                cells.Add(j < rowVals.Count ? Fmt(rowVals[j]) : string.Empty);
+            }
+            rows.Add(new MatrixRowViewModel(matrix.Labels[i], cells));
+        }
+
+        Rows = rows;
+    }
+
+    public IReadOnlyList<string> ColumnHeaders { get; }
+    public IReadOnlyList<MatrixRowViewModel> Rows { get; }
+
+    private static string Fmt(double? v) =>
+        v.HasValue ? v.Value.ToString("G4", CultureInfo.InvariantCulture) : string.Empty;
+}

--- a/src/Census.App/ViewModels/RunDetailViewModel.cs
+++ b/src/Census.App/ViewModels/RunDetailViewModel.cs
@@ -43,4 +43,28 @@ public sealed partial class RunDetailViewModel : ObservableObject
 
     [ObservableProperty]
     private EstimationStepViewModel? _selectedEstimation;
+
+    public IReadOnlyList<string> MatrixKinds { get; } = ["Correlation", "Covariance"];
+
+    [ObservableProperty]
+    private string _matrixKind = "Correlation";
+
+    /// <summary>The matrix shown in the Matrices tab for the selected estimation and kind.</summary>
+    public MatrixViewModel? CurrentMatrix => MatrixKind == "Covariance"
+        ? SelectedEstimation?.Covariance
+        : SelectedEstimation?.Correlation;
+
+    public bool HasMatrix => CurrentMatrix is not null;
+
+    partial void OnSelectedEstimationChanged(EstimationStepViewModel? value)
+    {
+        OnPropertyChanged(nameof(CurrentMatrix));
+        OnPropertyChanged(nameof(HasMatrix));
+    }
+
+    partial void OnMatrixKindChanged(string value)
+    {
+        OnPropertyChanged(nameof(CurrentMatrix));
+        OnPropertyChanged(nameof(HasMatrix));
+    }
 }

--- a/src/Census.App/Views/CompareWindow.axaml
+++ b/src/Census.App/Views/CompareWindow.axaml
@@ -1,0 +1,23 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:Census.App.ViewModels"
+        x:Class="Census.App.Views.CompareWindow"
+        x:DataType="vm:CompareViewModel"
+        Title="Compare runs"
+        Width="900" Height="600"
+        WindowStartupLocation="CenterOwner">
+
+  <DockPanel>
+    <Border DockPanel.Dock="Bottom" Background="#F3F3F3" BorderBrush="#C8C8C8" BorderThickness="0,1,0,0">
+      <Button Content="Close" IsCancel="True" HorizontalAlignment="Right" Margin="8" />
+    </Border>
+
+    <DataGrid x:Name="CompareGrid"
+              ItemsSource="{Binding Rows}"
+              IsReadOnly="True"
+              GridLinesVisibility="All"
+              CanUserResizeColumns="True"
+              AutoGenerateColumns="False" />
+  </DockPanel>
+
+</Window>

--- a/src/Census.App/Views/CompareWindow.axaml.cs
+++ b/src/Census.App/Views/CompareWindow.axaml.cs
@@ -1,0 +1,34 @@
+using Avalonia.Controls;
+using Avalonia.Data;
+using Census.App.ViewModels;
+
+namespace Census.App.Views;
+
+public partial class CompareWindow : Window
+{
+    public CompareWindow() => InitializeComponent();
+
+    public CompareWindow(CompareViewModel vm) : this()
+    {
+        DataContext = vm;
+
+        // First column: the parameter/metric label.
+        CompareGrid.Columns.Add(new DataGridTextColumn
+        {
+            Header = "Parameter",
+            Binding = new Binding(nameof(CompareRowViewModel.Label)),
+            Width = new DataGridLength(170),
+        });
+
+        // One column per run, bound to the matching index in each row's Values list.
+        for (var i = 0; i < vm.RunHeaders.Count; i++)
+        {
+            CompareGrid.Columns.Add(new DataGridTextColumn
+            {
+                Header = vm.RunHeaders[i],
+                Binding = new Binding($"Values[{i}]"),
+                Width = new DataGridLength(110),
+            });
+        }
+    }
+}

--- a/src/Census.App/Views/MainWindow.axaml
+++ b/src/Census.App/Views/MainWindow.axaml
@@ -91,7 +91,7 @@
 
         <Rectangle Width="1" Fill="#C8C8C8" Margin="4,4" />
 
-        <Button Classes="tool" Command="{Binding CompareCommand}" ToolTip.Tip="Compare runs">
+        <Button Classes="tool" Command="{Binding CompareCommand}" ToolTip.Tip="Compare selected runs (Ctrl/Shift-click two or more)">
           <StackPanel><TextBlock Classes="glyph" Text="&#xE8AB;" /><TextBlock Classes="label" Text="Compare" /></StackPanel>
         </Button>
         <Button Classes="tool" Command="{Binding DiagnosticsCommand}" ToolTip.Tip="Run diagnostics">
@@ -169,8 +169,11 @@
       <Grid Grid.Column="2" RowDefinitions="3*,4,2*">
 
         <DataGrid Grid.Row="0"
+                  x:Name="RunGrid"
                   ItemsSource="{Binding Runs}"
                   SelectedItem="{Binding SelectedRun}"
+                  SelectionMode="Extended"
+                  SelectionChanged="OnRunSelectionChanged"
                   IsReadOnly="True"
                   GridLinesVisibility="Horizontal"
                   CanUserReorderColumns="True"

--- a/src/Census.App/Views/MainWindow.axaml.cs
+++ b/src/Census.App/Views/MainWindow.axaml.cs
@@ -1,8 +1,16 @@
 using Avalonia.Controls;
+using Census.App.ViewModels;
 
 namespace Census.App.Views;
 
 public partial class MainWindow : Window
 {
     public MainWindow() => InitializeComponent();
+
+    // Push the grid's multi-selection to the view model for the Compare action.
+    private void OnRunSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (DataContext is MainWindowViewModel vm && sender is DataGrid grid)
+            vm.SetCompareSelection(grid.SelectedItems);
+    }
 }

--- a/src/Census.App/Views/MatrixView.axaml
+++ b/src/Census.App/Views/MatrixView.axaml
@@ -1,0 +1,46 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="Census.App.Views.MatrixView"
+             x:CompileBindings="False">
+
+  <StackPanel Margin="8">
+
+    <!-- Header row: empty corner + column labels -->
+    <StackPanel Orientation="Horizontal">
+      <Border Width="120" />
+      <ItemsControl ItemsSource="{Binding ColumnHeaders}">
+        <ItemsControl.ItemsPanel>
+          <ItemsPanelTemplate><StackPanel Orientation="Horizontal" /></ItemsPanelTemplate>
+        </ItemsControl.ItemsPanel>
+        <ItemsControl.ItemTemplate>
+          <DataTemplate>
+            <TextBlock Text="{Binding}" Width="90" Margin="2,0" FontWeight="SemiBold" TextAlignment="Right" />
+          </DataTemplate>
+        </ItemsControl.ItemTemplate>
+      </ItemsControl>
+    </StackPanel>
+
+    <!-- Data rows: row label + cells -->
+    <ItemsControl ItemsSource="{Binding Rows}">
+      <ItemsControl.ItemTemplate>
+        <DataTemplate>
+          <StackPanel Orientation="Horizontal">
+            <TextBlock Text="{Binding Label}" Width="120" Margin="2,0" FontWeight="SemiBold" />
+            <ItemsControl ItemsSource="{Binding Cells}">
+              <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate><StackPanel Orientation="Horizontal" /></ItemsPanelTemplate>
+              </ItemsControl.ItemsPanel>
+              <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                  <TextBlock Text="{Binding}" Width="90" Margin="2,0" TextAlignment="Right" />
+                </DataTemplate>
+              </ItemsControl.ItemTemplate>
+            </ItemsControl>
+          </StackPanel>
+        </DataTemplate>
+      </ItemsControl.ItemTemplate>
+    </ItemsControl>
+
+  </StackPanel>
+
+</UserControl>

--- a/src/Census.App/Views/MatrixView.axaml.cs
+++ b/src/Census.App/Views/MatrixView.axaml.cs
@@ -1,0 +1,8 @@
+using Avalonia.Controls;
+
+namespace Census.App.Views;
+
+public partial class MatrixView : UserControl
+{
+    public MatrixView() => InitializeComponent();
+}

--- a/src/Census.App/Views/RunDetailView.axaml
+++ b/src/Census.App/Views/RunDetailView.axaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:Census.App.ViewModels"
+             xmlns:views="using:Census.App.Views"
              x:Class="Census.App.Views.RunDetailView"
              x:DataType="vm:RunDetailViewModel">
 
@@ -95,8 +96,24 @@
       </TabItem>
 
       <TabItem Header="Matrices">
-        <TextBlock Margin="12" Foreground="#888"
-                   Text="Variance-covariance and correlation matrices are not yet available." />
+        <DockPanel>
+          <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="8,6" Spacing="8">
+            <TextBlock Text="Matrix:" VerticalAlignment="Center" />
+            <ComboBox Width="150" ItemsSource="{Binding MatrixKinds}" SelectedItem="{Binding MatrixKind}" />
+          </StackPanel>
+          <TextBlock DockPanel.Dock="Top" Margin="12" Foreground="#888"
+                     IsVisible="{Binding !HasMatrix}"
+                     Text="No matrix available for this estimation (no covariance step, or not imported)." />
+          <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+            <ContentControl Content="{Binding CurrentMatrix}">
+              <ContentControl.DataTemplates>
+                <DataTemplate DataType="vm:MatrixViewModel">
+                  <views:MatrixView />
+                </DataTemplate>
+              </ContentControl.DataTemplates>
+            </ContentControl>
+          </ScrollViewer>
+        </DockPanel>
       </TabItem>
 
       <TabItem Header="Miscellaneous">

--- a/src/Census.Domain/Run.cs
+++ b/src/Census.Domain/Run.cs
@@ -73,9 +73,26 @@ public sealed record Estimation
     /// <summary>Covariance-step elapsed time in seconds (NONMEM <c>covariance_elapsed_time</c>).</summary>
     public double? CovarianceTime { get; init; }
 
+    /// <summary>Variance-covariance matrix of the estimates, if a covariance step ran.</summary>
+    public NamedMatrix? Covariance { get; init; }
+
+    /// <summary>Correlation matrix of the estimates (SE on the diagonal), if available.</summary>
+    public NamedMatrix? Correlation { get; init; }
+
     public IReadOnlyList<Parameter> Parameters { get; init; } = [];
 
     public IReadOnlyList<string> Warnings { get; init; } = [];
+}
+
+/// <summary>
+/// A labelled lower-triangular symmetric matrix (covariance/correlation of the estimates).
+/// <see cref="Values"/>[i] holds the i+1 entries of row i (columns 0..i).
+/// </summary>
+public sealed record NamedMatrix
+{
+    public required IReadOnlyList<string> Labels { get; init; }
+
+    public required IReadOnlyList<IReadOnlyList<double?>> Values { get; init; }
 }
 
 public enum ParameterKind

--- a/src/Census.Import/NonmemXmlImporter.cs
+++ b/src/Census.Import/NonmemXmlImporter.cs
@@ -118,6 +118,8 @@ public sealed class NonmemXmlImporter : IRunImporter
                 ConditionNumber = conditionNumber,
                 EstimationTime = estimationTime,
                 CovarianceTime = covarianceTime,
+                Covariance = ParseNamedMatrix(El(estEl, "covariance")),
+                Correlation = ParseNamedMatrix(El(estEl, "correlation")),
                 Parameters = [.. thetas, .. omegas, .. sigmas],
                 Warnings = warnings,
             });
@@ -188,6 +190,28 @@ public sealed class NonmemXmlImporter : IRunImporter
         }
 
         return result;
+    }
+
+    // Parse a labelled lower-triangular matrix (covariance/correlation) from its XML element.
+    private static NamedMatrix? ParseNamedMatrix(XElement? matEl)
+    {
+        if (matEl is null)
+        {
+            return null;
+        }
+
+        var rows = Els(matEl, "row").ToList();
+        if (rows.Count == 0)
+        {
+            return null;
+        }
+
+        var labels = rows.Select(r => Attr(r, "rname")?.Trim() ?? string.Empty).ToList();
+        var values = rows
+            .Select(r => (IReadOnlyList<double?>)Els(r, "col").Select(c => ParseDouble(c.Value)).ToList())
+            .ToList();
+
+        return new NamedMatrix { Labels = labels, Values = values };
     }
 
     // Shrinkage tables come in two layouts:

--- a/src/Census.Storage/Migrations/0003_matrices.sql
+++ b/src/Census.Storage/Migrations/0003_matrices.sql
@@ -1,0 +1,6 @@
+-- Census project schema, version 3.
+-- Stores the variance-covariance and correlation matrices of the estimates as JSON,
+-- since they are read and displayed whole rather than queried per-element.
+
+ALTER TABLE estimations ADD COLUMN CovarianceJson  TEXT;
+ALTER TABLE estimations ADD COLUMN CorrelationJson TEXT;

--- a/src/Census.Storage/SqliteProjectStore.cs
+++ b/src/Census.Storage/SqliteProjectStore.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text.Json;
 using Census.Domain;
 using Dapper;
 using Microsoft.Data.Sqlite;
@@ -82,11 +83,23 @@ public sealed class SqliteProjectStore : IProjectStore
         {
             var estId = connection.ExecuteScalar<long>(
                 """
-                INSERT INTO estimations (RunId, Number, Method, Ofv, DOfv, ConditionNumber, EstimationTime, CovarianceTime)
-                VALUES (@runId, @Number, @Method, @Ofv, @DOfv, @ConditionNumber, @EstimationTime, @CovarianceTime);
+                INSERT INTO estimations (RunId, Number, Method, Ofv, DOfv, ConditionNumber, EstimationTime, CovarianceTime, CovarianceJson, CorrelationJson)
+                VALUES (@runId, @Number, @Method, @Ofv, @DOfv, @ConditionNumber, @EstimationTime, @CovarianceTime, @CovarianceJson, @CorrelationJson);
                 SELECT last_insert_rowid();
                 """,
-                new { runId, estimation.Number, estimation.Method, estimation.Ofv, estimation.DOfv, estimation.ConditionNumber, estimation.EstimationTime, estimation.CovarianceTime },
+                new
+                {
+                    runId,
+                    estimation.Number,
+                    estimation.Method,
+                    estimation.Ofv,
+                    estimation.DOfv,
+                    estimation.ConditionNumber,
+                    estimation.EstimationTime,
+                    estimation.CovarianceTime,
+                    CovarianceJson = SerializeMatrix(estimation.Covariance),
+                    CorrelationJson = SerializeMatrix(estimation.Correlation),
+                },
                 tx);
 
             foreach (var p in estimation.Parameters)
@@ -132,7 +145,7 @@ public sealed class SqliteProjectStore : IProjectStore
                 new { id = r.Id }).ToList();
 
             var estRows = connection.Query<EstimationRow>(
-                "SELECT Id, Number, Method, Ofv, DOfv, ConditionNumber, EstimationTime, CovarianceTime FROM estimations WHERE RunId = @id ORDER BY Number;",
+                "SELECT Id, Number, Method, Ofv, DOfv, ConditionNumber, EstimationTime, CovarianceTime, CovarianceJson, CorrelationJson FROM estimations WHERE RunId = @id ORDER BY Number;",
                 new { id = r.Id }).ToList();
 
             var estimations = new List<Estimation>(estRows.Count);
@@ -165,6 +178,8 @@ public sealed class SqliteProjectStore : IProjectStore
                     ConditionNumber = e.ConditionNumber,
                     EstimationTime = e.EstimationTime,
                     CovarianceTime = e.CovarianceTime,
+                    Covariance = DeserializeMatrix(e.CovarianceJson),
+                    Correlation = DeserializeMatrix(e.CorrelationJson),
                     Parameters = parameters,
                     Warnings = warnings,
                 });
@@ -212,7 +227,45 @@ public sealed class SqliteProjectStore : IProjectStore
     private sealed record RunRow(long Id, string RunNo, long IRunNo, string? ParentNo, string? Comment, long KeyRun, long? ObsRecs, long? Individuals,
         string? StartDateTime, string? StopDateTime, double? TotalCpuTime, double? PostElapsedTime, double? FinalOutputElapsedTime);
 
-    private sealed record EstimationRow(long Id, long Number, string? Method, double? Ofv, double? DOfv, double? ConditionNumber, double? EstimationTime, double? CovarianceTime);
+    private sealed record EstimationRow(long Id, long Number, string? Method, double? Ofv, double? DOfv, double? ConditionNumber, double? EstimationTime, double? CovarianceTime, string? CovarianceJson, string? CorrelationJson);
+
+    // Matrices are stored as JSON (read/displayed whole, never queried per-element).
+    private static readonly JsonSerializerOptions MatrixJsonOptions = new();
+
+    private sealed record MatrixDto(List<string> Labels, List<List<double?>> Values);
+
+    private static string? SerializeMatrix(NamedMatrix? matrix)
+    {
+        if (matrix is null)
+        {
+            return null;
+        }
+
+        var dto = new MatrixDto(
+            matrix.Labels.ToList(),
+            matrix.Values.Select(row => row.ToList()).ToList());
+        return JsonSerializer.Serialize(dto, MatrixJsonOptions);
+    }
+
+    private static NamedMatrix? DeserializeMatrix(string? json)
+    {
+        if (string.IsNullOrEmpty(json))
+        {
+            return null;
+        }
+
+        var dto = JsonSerializer.Deserialize<MatrixDto>(json, MatrixJsonOptions);
+        if (dto is null)
+        {
+            return null;
+        }
+
+        return new NamedMatrix
+        {
+            Labels = dto.Labels,
+            Values = dto.Values.Select(row => (IReadOnlyList<double?>)row).ToList(),
+        };
+    }
 
     private sealed record ParameterRow(string Kind, long Index, string? Label, double? Estimate, double? StandardError, double? Shrinkage);
 }

--- a/tests/Census.Tests/NonmemXmlImporterTests.cs
+++ b/tests/Census.Tests/NonmemXmlImporterTests.cs
@@ -265,6 +265,45 @@ public sealed class NonmemXmlImporterTests
     }
 
     [Fact]
+    public void Import_InlineXml_ParsesCovarianceAndCorrelationMatrices()
+    {
+        var xml = """
+            <?xml version="1.0" encoding="ASCII"?>
+            <nm:output xmlns:nm="http://namespaces.oreilly.com/xmlnut/address">
+              <nm:nonmem nm:version='7.3.0'>
+                <nm:problem nm:number='1'>
+                  <nm:estimation nm:number='1' nm:type='0'>
+                    <nm:estimation_method>focei</nm:estimation_method>
+                    <nm:termination_status>0</nm:termination_status>
+                    <nm:final_objective_function>-100.0</nm:final_objective_function>
+                    <nm:covariance>
+                      <nm:row nm:rname='THETA1'><nm:col nm:cname='THETA1'>0.04</nm:col></nm:row>
+                      <nm:row nm:rname='THETA2'><nm:col nm:cname='THETA1'>0.01</nm:col><nm:col nm:cname='THETA2'>0.09</nm:col></nm:row>
+                    </nm:covariance>
+                    <nm:correlation>
+                      <nm:row nm:rname='THETA1'><nm:col nm:cname='THETA1'>0.20</nm:col></nm:row>
+                      <nm:row nm:rname='THETA2'><nm:col nm:cname='THETA1'>0.17</nm:col><nm:col nm:cname='THETA2'>0.30</nm:col></nm:row>
+                    </nm:correlation>
+                  </nm:estimation>
+                </nm:problem>
+              </nm:nonmem>
+            </nm:output>
+            """;
+
+        var run = new NonmemXmlImporter().ImportXml(xml, sourcePath: "runR012.xml");
+        var est = Assert.Single(run.Estimations);
+
+        Assert.NotNull(est.Covariance);
+        Assert.Equal(["THETA1", "THETA2"], est.Covariance!.Labels);
+        Assert.Equal(0.04, est.Covariance.Values[0][0]!.Value, precision: 6);
+        Assert.Equal(0.01, est.Covariance.Values[1][0]!.Value, precision: 6);
+        Assert.Equal(0.09, est.Covariance.Values[1][1]!.Value, precision: 6);
+
+        Assert.NotNull(est.Correlation);
+        Assert.Equal(0.17, est.Correlation!.Values[1][0]!.Value, precision: 6);
+    }
+
+    [Fact]
     public void Import_InlineXml_ConditionNumber_EquicorrelationMatrix3x3()
     {
         // A 3x3 correlation matrix with 1 on the diagonal and 0.5 off-diagonal has

--- a/tests/Census.Tests/SqliteProjectStoreTests.cs
+++ b/tests/Census.Tests/SqliteProjectStoreTests.cs
@@ -48,6 +48,12 @@ public sealed class SqliteProjectStoreTests : IDisposable
         Assert.Equal(45.6, est.CovarianceTime);
         Assert.Equal("Rounding errors", Assert.Single(est.Warnings));
 
+        Assert.NotNull(est.Correlation);
+        Assert.Equal(["CL", "V"], est.Correlation!.Labels);
+        Assert.Equal(0.25, est.Correlation.Values[1][0]!.Value);
+        Assert.NotNull(est.Covariance);
+        Assert.Equal(0.02, est.Covariance!.Values[0][0]!.Value);
+
         Assert.Equal(2, est.Parameters.Count);
         var theta = Assert.Single(est.Parameters, p => p.Kind == ParameterKind.Theta);
         Assert.Equal(1, theta.Index);
@@ -108,6 +114,16 @@ public sealed class SqliteProjectStoreTests : IDisposable
                 ConditionNumber = 12.3,
                 EstimationTime = 123.4,
                 CovarianceTime = 45.6,
+                Correlation = new NamedMatrix
+                {
+                    Labels = ["CL", "V"],
+                    Values = [[0.15], [0.25, 0.80]],
+                },
+                Covariance = new NamedMatrix
+                {
+                    Labels = ["CL", "V"],
+                    Values = [[0.02], [0.01, 0.64]],
+                },
                 Warnings = ["Rounding errors"],
                 Parameters =
                 [


### PR DESCRIPTION
## Summary

Fills in two of the placeholder UI areas: the **Compare** action and the **Matrices** tab.

## Compare
- Run grid now supports extended multi-selection.
- The Compare toolbar action compares only the **selected** runs (disabled until 2+ selected) and opens a side-by-side window: OFV, dOFV, condition number, then every theta/omega/sigma estimate (runs as columns, generated dynamically).
- Selection order is preserved: the **first selected run is the reference**, and each run's **dOFV is computed relative to it** (row labelled "dOFV (vs first)").

## Matrices
- **Domain:** `NamedMatrix` (labelled lower-triangular); `Estimation` gains `Covariance` and `Correlation`.
- **Importer:** parses `<covariance>` and `<correlation>` elements.
- **Storage:** migration `0003` adds JSON columns; matrices are serialized and round-tripped.
- **UI:** the Matrices tab shows the selected estimation's correlation or covariance matrix (toggle), rendered via a reusable `MatrixView`.

## Tests
44 xUnit tests pass (added importer matrix-parsing and storage round-trip of both matrices). Release build clean; app launches without errors.

## Notes
- **Re-import** existing projects to populate the matrices (computed at import time).
- dOFV in Compare resolves against the first selected run; for a Shift-click range the "first" is the topmost row in the range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)