### PR TITLE
Run context menu, multi-color flags, edit dialog, and sibling-file indexing

### DIFF
--- a/src/Census.App/ViewModels/EditRunViewModel.cs
+++ b/src/Census.App/ViewModels/EditRunViewModel.cs
@@ -1,0 +1,29 @@
+using Census.Domain;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Census.App.ViewModels;
+
+/// <summary>Editable run metadata shown in the Edit dialog: parent run and comment.</summary>
+public sealed partial class EditRunViewModel : ObservableObject
+{
+    public EditRunViewModel(Run run, IEnumerable<string> otherRunNumbers)
+    {
+        RunNo = run.RunNo;
+        Comment = run.Comment ?? string.Empty;
+        ParentNo = run.ParentNo ?? string.Empty;
+
+        // "" lets the user clear the parent; the rest are the other runs in the project.
+        ParentOptions = new[] { string.Empty }
+            .Concat(otherRunNumbers)
+            .ToList();
+    }
+
+    public string RunNo { get; }
+    public IReadOnlyList<string> ParentOptions { get; }
+
+    [ObservableProperty]
+    private string _parentNo = string.Empty;
+
+    [ObservableProperty]
+    private string _comment = string.Empty;
+}

--- a/src/Census.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Census.App/ViewModels/MainWindowViewModel.cs
@@ -168,6 +168,21 @@ public partial class MainWindowViewModel : ObservableObject
     }
 
     [RelayCommand(CanExecute = nameof(IsRunSelected))]
+    private void FlagRun() => SetSelectedRunKeyFlag(true);
+
+    [RelayCommand(CanExecute = nameof(IsRunSelected))]
+    private void UnflagRun() => SetSelectedRunKeyFlag(false);
+
+    private void SetSelectedRunKeyFlag(bool keyRun)
+    {
+        if (SelectedRun is null) return;
+        var runNo = SelectedRun.RunNo;
+        _store.SetKeyRun(runNo, keyRun);
+        RefreshRuns();
+        SelectedRun = Runs.FirstOrDefault(r => r.RunNo == runNo);
+    }
+
+    [RelayCommand(CanExecute = nameof(IsRunSelected))]
     private void DeleteRun()
     {
         if (SelectedRun is null) return;

--- a/src/Census.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Census.App/ViewModels/MainWindowViewModel.cs
@@ -168,16 +168,30 @@ public partial class MainWindowViewModel : ObservableObject
     }
 
     [RelayCommand(CanExecute = nameof(IsRunSelected))]
-    private void FlagRun() => SetSelectedRunKeyFlag(true);
+    private void SetFlag(string? flag)
+    {
+        if (SelectedRun is null || !int.TryParse(flag, out var value)) return;
+        var runNo = SelectedRun.RunNo;
+        _store.SetFlag(runNo, value);
+        RefreshRuns();
+        SelectedRun = Runs.FirstOrDefault(r => r.RunNo == runNo);
+    }
 
     [RelayCommand(CanExecute = nameof(IsRunSelected))]
-    private void UnflagRun() => SetSelectedRunKeyFlag(false);
-
-    private void SetSelectedRunKeyFlag(bool keyRun)
+    private async Task EditRunAsync()
     {
         if (SelectedRun is null) return;
+
+        var others = Runs.Select(r => r.RunNo).Where(n => n != SelectedRun.RunNo);
+        var vm = new EditRunViewModel(SelectedRun.Model, others);
+        var win = new EditRunWindow { DataContext = vm };
+        var owner = (Avalonia.Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.MainWindow;
+        if (owner is null) return;
+
+        if (!await win.ShowDialog<bool>(owner)) return;
+
         var runNo = SelectedRun.RunNo;
-        _store.SetKeyRun(runNo, keyRun);
+        _store.UpdateRun(runNo, string.IsNullOrWhiteSpace(vm.ParentNo) ? null : vm.ParentNo, vm.Comment);
         RefreshRuns();
         SelectedRun = Runs.FirstOrDefault(r => r.RunNo == runNo);
     }

--- a/src/Census.App/ViewModels/RunSummaryViewModel.cs
+++ b/src/Census.App/ViewModels/RunSummaryViewModel.cs
@@ -36,7 +36,7 @@ public sealed class RunSummaryViewModel
         ConditionNumber = lastEst?.ConditionNumber?.ToString("0", System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty;
         ObsRecs = run.ObsRecs?.ToString() ?? string.Empty;
         Individuals = run.Individuals?.ToString() ?? string.Empty;
-        KeyRun = run.KeyRun;
+        Flag = run.Flag;
         WarningCount = run.Estimations.Sum(e => e.Warnings.Count);
 
         // Run-level timings (apply to the whole run). Show datetimes with a space, not 'T'.
@@ -54,17 +54,26 @@ public sealed class RunSummaryViewModel
     public string ConditionNumber { get; }
     public string ObsRecs { get; }
     public string Individuals { get; }
-    public bool KeyRun { get; }
+    public int Flag { get; }
     public int WarningCount { get; }
     public string Warnings => WarningCount > 0 ? WarningCount.ToString() : string.Empty;
     public string StartDateTime { get; }
     public string StopDateTime { get; }
     public string TotalCpuTime { get; }
 
-    /// <summary>Status circle in the run list: green = key run, red = has warnings, else none.</summary>
-    public IBrush FlagBrush => KeyRun
-        ? Brushes.MediumSeaGreen
-        : WarningCount > 0 ? Brushes.IndianRed : Brushes.Transparent;
+    // Flag colour palette, indexed by Flag (0 = unflagged).
+    private static readonly IBrush[] FlagBrushes =
+    [
+        Brushes.Transparent,    // 0 = none
+        Brushes.IndianRed,      // 1 = red
+        Brushes.Orange,         // 2 = orange
+        Brushes.Gold,           // 3 = yellow
+        Brushes.MediumSeaGreen, // 4 = green
+        Brushes.CornflowerBlue, // 5 = blue
+    ];
+
+    /// <summary>Flag circle colour in the run list, from the user-set flag (0-5).</summary>
+    public IBrush FlagBrush => Flag >= 0 && Flag < FlagBrushes.Length ? FlagBrushes[Flag] : Brushes.Transparent;
 
     /// <summary>dOFV is shown in red when it is non-zero (matches the original Census UI).</summary>
     public IBrush DOfvBrush =>

--- a/src/Census.App/Views/EditRunWindow.axaml
+++ b/src/Census.App/Views/EditRunWindow.axaml
@@ -1,0 +1,32 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:Census.App.ViewModels"
+        x:Class="Census.App.Views.EditRunWindow"
+        x:DataType="vm:EditRunViewModel"
+        Title="Edit run"
+        Width="420" Height="300"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False">
+
+  <DockPanel Margin="12">
+    <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal"
+                HorizontalAlignment="Right" Spacing="8" Margin="0,12,0,0">
+      <Button Content="Save" Click="OnSave" IsDefault="True" />
+      <Button Content="Cancel" Click="OnCancel" IsCancel="True" />
+    </StackPanel>
+
+    <Grid RowDefinitions="Auto,Auto,Auto" ColumnDefinitions="90,*" RowSpacing="8">
+      <TextBlock Grid.Row="0" Grid.Column="0" Text="Run" VerticalAlignment="Center" />
+      <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding RunNo}" FontWeight="SemiBold" VerticalAlignment="Center" />
+
+      <TextBlock Grid.Row="1" Grid.Column="0" Text="Parent" VerticalAlignment="Center" />
+      <ComboBox Grid.Row="1" Grid.Column="1" HorizontalAlignment="Stretch"
+                ItemsSource="{Binding ParentOptions}" SelectedItem="{Binding ParentNo}" />
+
+      <TextBlock Grid.Row="2" Grid.Column="0" Text="Comment" VerticalAlignment="Top" Margin="0,4,0,0" />
+      <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Comment}"
+               AcceptsReturn="True" TextWrapping="Wrap" Height="120" />
+    </Grid>
+  </DockPanel>
+
+</Window>

--- a/src/Census.App/Views/EditRunWindow.axaml.cs
+++ b/src/Census.App/Views/EditRunWindow.axaml.cs
@@ -1,0 +1,13 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+namespace Census.App.Views;
+
+public partial class EditRunWindow : Window
+{
+    public EditRunWindow() => InitializeComponent();
+
+    private void OnSave(object? sender, RoutedEventArgs e) => Close(true);
+
+    private void OnCancel(object? sender, RoutedEventArgs e) => Close(false);
+}

--- a/src/Census.App/Views/MainWindow.axaml
+++ b/src/Census.App/Views/MainWindow.axaml
@@ -182,8 +182,27 @@
                   AutoGenerateColumns="False">
           <DataGrid.ContextMenu>
             <ContextMenu x:CompileBindings="False">
-              <MenuItem Header="Flag as key run" Command="{Binding FlagRunCommand}" />
-              <MenuItem Header="Unflag" Command="{Binding UnflagRunCommand}" />
+              <MenuItem Header="Flag">
+                <MenuItem Header="Red" Command="{Binding SetFlagCommand}" CommandParameter="1">
+                  <MenuItem.Icon><Ellipse Width="12" Height="12" Fill="IndianRed" /></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Orange" Command="{Binding SetFlagCommand}" CommandParameter="2">
+                  <MenuItem.Icon><Ellipse Width="12" Height="12" Fill="Orange" /></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Yellow" Command="{Binding SetFlagCommand}" CommandParameter="3">
+                  <MenuItem.Icon><Ellipse Width="12" Height="12" Fill="Gold" /></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Green" Command="{Binding SetFlagCommand}" CommandParameter="4">
+                  <MenuItem.Icon><Ellipse Width="12" Height="12" Fill="MediumSeaGreen" /></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Blue" Command="{Binding SetFlagCommand}" CommandParameter="5">
+                  <MenuItem.Icon><Ellipse Width="12" Height="12" Fill="CornflowerBlue" /></MenuItem.Icon>
+                </MenuItem>
+                <Separator />
+                <MenuItem Header="Unflag" Command="{Binding SetFlagCommand}" CommandParameter="0" />
+              </MenuItem>
+              <Separator />
+              <MenuItem Header="Edit…" Command="{Binding EditRunCommand}" />
               <Separator />
               <MenuItem Header="Export…" Command="{Binding ExportRunCommand}" />
               <MenuItem Header="Archive…" Command="{Binding ArchiveRunCommand}" />

--- a/src/Census.App/Views/MainWindow.axaml
+++ b/src/Census.App/Views/MainWindow.axaml
@@ -174,11 +174,24 @@
                   SelectedItem="{Binding SelectedRun}"
                   SelectionMode="Extended"
                   SelectionChanged="OnRunSelectionChanged"
+                  PointerPressed="OnRunGridPointerPressed"
                   IsReadOnly="True"
                   GridLinesVisibility="Horizontal"
                   CanUserReorderColumns="True"
                   CanUserResizeColumns="True"
                   AutoGenerateColumns="False">
+          <DataGrid.ContextMenu>
+            <ContextMenu x:CompileBindings="False">
+              <MenuItem Header="Flag as key run" Command="{Binding FlagRunCommand}" />
+              <MenuItem Header="Unflag" Command="{Binding UnflagRunCommand}" />
+              <Separator />
+              <MenuItem Header="Export…" Command="{Binding ExportRunCommand}" />
+              <MenuItem Header="Archive…" Command="{Binding ArchiveRunCommand}" />
+              <Separator />
+              <MenuItem Header="Compare selected" Command="{Binding CompareCommand}" />
+              <MenuItem Header="Delete" Command="{Binding DeleteRunCommand}" />
+            </ContextMenu>
+          </DataGrid.ContextMenu>
           <DataGrid.Columns>
             <DataGridTextColumn Header="Run" Binding="{Binding RunNo}" Width="80" />
             <DataGridTemplateColumn Header="Flag" Width="44">

--- a/src/Census.App/Views/MainWindow.axaml.cs
+++ b/src/Census.App/Views/MainWindow.axaml.cs
@@ -1,4 +1,7 @@
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.VisualTree;
 using Census.App.ViewModels;
 
 namespace Census.App.Views;
@@ -12,5 +15,23 @@ public partial class MainWindow : Window
     {
         if (DataContext is MainWindowViewModel vm && sender is DataGrid grid)
             vm.SetCompareSelection(grid.SelectedItems);
+    }
+
+    // Right-click should target the row under the pointer. If it is not already part of the
+    // current multi-selection, select just that row before the context menu opens.
+    private void OnRunGridPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (!e.GetCurrentPoint(sender as Visual).Properties.IsRightButtonPressed)
+            return;
+
+        var visual = e.Source as Visual;
+        while (visual is not null and not DataGridRow)
+            visual = visual.GetVisualParent();
+
+        if (visual is DataGridRow { DataContext: RunSummaryViewModel row }
+            && (RunGrid.SelectedItems is null || !RunGrid.SelectedItems.Contains(row)))
+        {
+            RunGrid.SelectedItem = row;
+        }
     }
 }

--- a/src/Census.Cli/Commands/Commands.cs
+++ b/src/Census.Cli/Commands/Commands.cs
@@ -62,7 +62,7 @@ internal sealed class ListCommand : Command<ListCommand.Settings>
                 run.ParentNo ?? string.Empty,
                 first?.Method ?? string.Empty,
                 first?.Ofv?.ToString("0.000", System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty,
-                run.KeyRun ? "[green]✓[/]" : string.Empty);
+                run.Flag != 0 ? "[green]✓[/]" : string.Empty);
         }
 
         AnsiConsole.Write(table);

--- a/src/Census.Domain/Run.cs
+++ b/src/Census.Domain/Run.cs
@@ -18,8 +18,8 @@ public sealed record Run
     /// <summary>User comment.</summary>
     public string? Comment { get; init; }
 
-    /// <summary>Whether the user flagged this as a key run.</summary>
-    public bool KeyRun { get; init; }
+    /// <summary>User flag colour: 0 = unflagged, 1-5 = colour index (red/orange/yellow/green/blue).</summary>
+    public int Flag { get; init; }
 
     /// <summary>Number of observation records in the dataset.</summary>
     public int? ObsRecs { get; init; }

--- a/src/Census.Import/NonmemXmlImporter.cs
+++ b/src/Census.Import/NonmemXmlImporter.cs
@@ -22,8 +22,125 @@ public sealed class NonmemXmlImporter : IRunImporter
         var md5 = ComputeMd5(sourcePath);
         return run with
         {
-            Files = [new FileArtifact { Role = "output", Path = sourcePath, Md5 = md5 }],
+            Files = DiscoverRelatedFiles(sourcePath, md5, ExtractControlStream(xml)),
         };
+    }
+
+    // Index the run's sibling files by path (control stream, listing, ext/cov/cor/…, tables and
+    // the $DATA dataset). Only paths are recorded — file contents are never copied into the project.
+    private static List<FileArtifact> DiscoverRelatedFiles(string xmlPath, string xmlMd5, string? controlStream)
+    {
+        var fullXml = Path.GetFullPath(xmlPath);
+        var dir = Path.GetDirectoryName(fullXml);
+        var stem = Path.GetFileNameWithoutExtension(xmlPath);
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { fullXml };
+        var files = new List<FileArtifact>
+        {
+            new() { Role = "output", Path = xmlPath, Md5 = xmlMd5 },
+        };
+
+        if (dir is null || !Directory.Exists(dir))
+        {
+            return files;
+        }
+
+        // Same-stem files (run27.*): model, listing, ext, cov, cor, coi, phi, grd, shk, …
+        foreach (var path in Directory.EnumerateFiles(dir, stem + ".*"))
+        {
+            if (seen.Add(Path.GetFullPath(path)))
+                files.Add(new FileArtifact { Role = RoleForExtension(Path.GetExtension(path)), Path = path });
+        }
+
+        // Table files (*tab*) belonging to this run (matched by trailing run number).
+        var runNumber = TrailingNumber(stem);
+        foreach (var path in Directory.EnumerateFiles(dir, "*tab*"))
+        {
+            var full = Path.GetFullPath(path);
+            if (seen.Contains(full))
+                continue;
+
+            var tableNumber = TrailingNumber(Path.GetFileNameWithoutExtension(path));
+            if (runNumber is not null && tableNumber is not null && runNumber != tableNumber)
+                continue;
+
+            seen.Add(full);
+            files.Add(new FileArtifact { Role = "table", Path = path });
+        }
+
+        // Dataset referenced by $DATA in the control stream, resolved relative to the run directory.
+        var dataName = ParseDataFileName(controlStream);
+        if (dataName is not null)
+        {
+            var dataPath = Path.GetFullPath(Path.IsPathRooted(dataName) ? dataName : Path.Combine(dir, dataName));
+            if (File.Exists(dataPath) && seen.Add(dataPath))
+                files.Add(new FileArtifact { Role = "data", Path = dataPath });
+        }
+
+        return files;
+    }
+
+    private static string RoleForExtension(string extWithDot)
+    {
+        var ext = extWithDot.TrimStart('.').ToLowerInvariant();
+        return ext switch
+        {
+            "lst" or "res" => "listing",
+            "ctl" or "mod" => "model",
+            "" => "file",
+            _ => ext,
+        };
+    }
+
+    // Trailing decimal number of a name, e.g. "runR027" -> 27, "sdtab27" -> 27, "sdtab" -> null.
+    private static int? TrailingNumber(string name)
+    {
+        var i = name.Length;
+        while (i > 0 && char.IsDigit(name[i - 1]))
+            i--;
+        return i < name.Length && int.TryParse(name.AsSpan(i), out var n) ? n : null;
+    }
+
+    // First token after $DATA in the control stream (handles quotes and trailing options).
+    private static string? ParseDataFileName(string? controlStream)
+    {
+        if (string.IsNullOrEmpty(controlStream))
+            return null;
+
+        foreach (var raw in controlStream.Split('\n'))
+        {
+            var line = raw.Trim();
+            if (!line.StartsWith("$DATA", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var rest = line[5..].Trim();
+            if (rest.Length == 0)
+                continue;
+
+            if (rest[0] is '"' or '\'')
+            {
+                var quote = rest[0];
+                var end = rest.IndexOf(quote, 1);
+                return end > 1 ? rest[1..end] : rest[1..];
+            }
+
+            var stop = rest.IndexOfAny([' ', '\t']);
+            return stop > 0 ? rest[..stop] : rest;
+        }
+
+        return null;
+    }
+
+    private static string? ExtractControlStream(string xml)
+    {
+        try
+        {
+            return El(XDocument.Parse(xml).Root, "control_stream")?.Value;
+        }
+        catch (System.Xml.XmlException)
+        {
+            return null;
+        }
     }
 
     /// <summary>Parse from an XML string. Exposed for testing without disk I/O.</summary>

--- a/src/Census.Storage/IProjectStore.cs
+++ b/src/Census.Storage/IProjectStore.cs
@@ -24,6 +24,9 @@ public interface IProjectStore
     /// <summary>Delete a run (and its estimations, parameters, warnings and file refs) by run number.</summary>
     void DeleteRun(string runNo);
 
-    /// <summary>Set or clear the "key run" flag for a run.</summary>
-    void SetKeyRun(string runNo, bool keyRun);
+    /// <summary>Set a run's flag colour (0 = unflagged, 1-5 = colour index).</summary>
+    void SetFlag(string runNo, int flag);
+
+    /// <summary>Update a run's editable metadata (parent and comment).</summary>
+    void UpdateRun(string runNo, string? parentNo, string? comment);
 }

--- a/src/Census.Storage/IProjectStore.cs
+++ b/src/Census.Storage/IProjectStore.cs
@@ -23,4 +23,7 @@ public interface IProjectStore
 
     /// <summary>Delete a run (and its estimations, parameters, warnings and file refs) by run number.</summary>
     void DeleteRun(string runNo);
+
+    /// <summary>Set or clear the "key run" flag for a run.</summary>
+    void SetKeyRun(string runNo, bool keyRun);
 }

--- a/src/Census.Storage/SqliteProjectStore.cs
+++ b/src/Census.Storage/SqliteProjectStore.cs
@@ -215,6 +215,14 @@ public sealed class SqliteProjectStore : IProjectStore
         connection.Execute("DELETE FROM runs WHERE RunNo = @runNo;", new { runNo });
     }
 
+    public void SetKeyRun(string runNo, bool keyRun)
+    {
+        using var connection = OpenConnection();
+        connection.Execute(
+            "UPDATE runs SET KeyRun = @keyRun WHERE RunNo = @runNo;",
+            new { keyRun = keyRun ? 1 : 0, runNo });
+    }
+
     private SqliteConnection OpenConnection()
     {
         var connection = new SqliteConnection(ConnectionString);

--- a/src/Census.Storage/SqliteProjectStore.cs
+++ b/src/Census.Storage/SqliteProjectStore.cs
@@ -59,7 +59,7 @@ public sealed class SqliteProjectStore : IProjectStore
                 run.IRunNo,
                 run.ParentNo,
                 run.Comment,
-                KeyRun = run.KeyRun ? 1 : 0,
+                KeyRun = run.Flag,
                 run.ObsRecs,
                 run.Individuals,
                 run.StartDateTime,
@@ -191,7 +191,7 @@ public sealed class SqliteProjectStore : IProjectStore
                 IRunNo = (int)r.IRunNo,
                 ParentNo = r.ParentNo,
                 Comment = r.Comment,
-                KeyRun = r.KeyRun != 0,
+                Flag = (int)r.KeyRun,
                 ObsRecs = (int?)r.ObsRecs,
                 Individuals = (int?)r.Individuals,
                 StartDateTime = r.StartDateTime,
@@ -215,12 +215,20 @@ public sealed class SqliteProjectStore : IProjectStore
         connection.Execute("DELETE FROM runs WHERE RunNo = @runNo;", new { runNo });
     }
 
-    public void SetKeyRun(string runNo, bool keyRun)
+    public void SetFlag(string runNo, int flag)
     {
         using var connection = OpenConnection();
         connection.Execute(
-            "UPDATE runs SET KeyRun = @keyRun WHERE RunNo = @runNo;",
-            new { keyRun = keyRun ? 1 : 0, runNo });
+            "UPDATE runs SET KeyRun = @flag WHERE RunNo = @runNo;",
+            new { flag, runNo });
+    }
+
+    public void UpdateRun(string runNo, string? parentNo, string? comment)
+    {
+        using var connection = OpenConnection();
+        connection.Execute(
+            "UPDATE runs SET ParentNo = @parentNo, Comment = @comment WHERE RunNo = @runNo;",
+            new { parentNo, comment, runNo });
     }
 
     private SqliteConnection OpenConnection()

--- a/tests/Census.Tests/NonmemXmlImporterTests.cs
+++ b/tests/Census.Tests/NonmemXmlImporterTests.cs
@@ -265,6 +265,56 @@ public sealed class NonmemXmlImporterTests
     }
 
     [Fact]
+    public void Import_IndexesSiblingRunFilesByPath()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "census-import-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "run1.ctl"), "$PROBLEM\n$DATA data1.csv IGNORE=@\n");
+            File.WriteAllText(Path.Combine(dir, "run1.ext"), "x");
+            File.WriteAllText(Path.Combine(dir, "run1.cov"), "x");
+            File.WriteAllText(Path.Combine(dir, "sdtab1"), "x");
+            File.WriteAllText(Path.Combine(dir, "data1.csv"), "ID,DV\n1,2\n");
+
+            var xml = """
+                <?xml version="1.0"?>
+                <output>
+                  <control_stream>$PROBLEM
+                $DATA data1.csv IGNORE=@</control_stream>
+                  <nonmem version="7.4.0">
+                    <problem number="1">
+                      <estimation number="1">
+                        <estimation_method>FOCEI</estimation_method>
+                        <final_objective_function>-1.0</final_objective_function>
+                      </estimation>
+                    </problem>
+                  </nonmem>
+                </output>
+                """;
+            var xmlPath = Path.Combine(dir, "run1.xml");
+            File.WriteAllText(xmlPath, xml);
+
+            var run = new NonmemXmlImporter().Import(xmlPath);
+            var roles = run.Files.Select(f => f.Role).ToList();
+
+            Assert.Contains("output", roles);   // the .xml itself
+            Assert.Contains("model", roles);     // run1.ctl
+            Assert.Contains("ext", roles);       // run1.ext
+            Assert.Contains("cov", roles);       // run1.cov
+            Assert.Contains("table", roles);     // sdtab1
+            Assert.Contains("data", roles);      // data1.csv via $DATA
+
+            // Paths are recorded; the data file resolves to the sibling csv.
+            Assert.Contains(run.Files, f => f.Role == "data" && f.Path.EndsWith("data1.csv", StringComparison.Ordinal));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
     public void Import_InlineXml_ParsesCovarianceAndCorrelationMatrices()
     {
         var xml = """

--- a/tests/Census.Tests/SqliteProjectStoreTests.cs
+++ b/tests/Census.Tests/SqliteProjectStoreTests.cs
@@ -26,7 +26,7 @@ public sealed class SqliteProjectStoreTests : IDisposable
         Assert.Equal("27", run.RunNo);
         Assert.Equal(27, run.IRunNo);
         Assert.Equal("12", run.ParentNo);
-        Assert.True(run.KeyRun);
+        Assert.Equal(3, run.Flag);
         Assert.Equal(1234, run.ObsRecs);
 
         var artifact = Assert.Single(run.Files);
@@ -66,6 +66,25 @@ public sealed class SqliteProjectStoreTests : IDisposable
     }
 
     [Fact]
+    public void SetFlag_And_UpdateRun_Persist()
+    {
+        var store = new SqliteProjectStore();
+        store.Create(_path);
+        store.SaveRun(SampleRun());
+
+        store.SetFlag("27", 5);
+        store.UpdateRun("27", parentNo: "9", comment: "edited comment");
+
+        var reopened = new SqliteProjectStore();
+        reopened.Open(_path);
+        var run = Assert.Single(reopened.GetRuns());
+
+        Assert.Equal(5, run.Flag);
+        Assert.Equal("9", run.ParentNo);
+        Assert.Equal("edited comment", run.Comment);
+    }
+
+    [Fact]
     public void Open_AppliesMigrationsIdempotently()
     {
         new SqliteProjectStore().Create(_path);
@@ -94,7 +113,7 @@ public sealed class SqliteProjectStoreTests : IDisposable
         IRunNo = 27,
         ParentNo = "12",
         Comment = "base model",
-        KeyRun = true,
+        Flag = 3,
         ObsRecs = 1234,
         Individuals = 56,
         StartDateTime = "2024-01-15T10:30:00",


### PR DESCRIPTION
## Summary

Restores the legacy run-list right-click menu and adds the capabilities behind it.

## Context menu
Right-click on the run grid: **Flag** (colour submenu) · **Edit…** · **Export…** · **Archive…** · **Compare selected** · **Delete**. Right-clicking a row selects it first (unless it is already in a multi-selection).

## Multi-colour flags
- `Run.KeyRun` (bool) → `Run.Flag` (int 0–5): 0 = unflagged, 1–5 = red/orange/yellow/green/blue (matching the legacy scheme).
- The flag circle in the run grid shows the chosen colour; persisted via `IProjectStore.SetFlag`.

## Edit dialog
- "Edit…" opens a dialog to change a run's **parent** (dropdown of other runs) and **comment**; persisted via `IProjectStore.UpdateRun`. Changing the parent updates dOFV/lineage on refresh.

## Sibling-file indexing
- On import, Census now records the **paths** of a run's related files (never the contents): same-stem files (`run27.*` → model/listing/ext/cov/cor/coi/phi/grd/shk/…), `*tab*` tables (matched by run number), and the `$DATA` dataset.
- The archiver already iterates `run.Files` and gates role `data` behind `--include-data`, so these now flow into archives.

## Tests
46 xUnit tests pass (added sibling-file discovery test and a SetFlag/UpdateRun round-trip). Release build clean; app launches.

## Notes
- **Re-import** existing projects to populate flags-as-int and the new file references.
- Legacy "Label" / Xpose table-name fields and a desktop include-data toggle are possible follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)